### PR TITLE
fix(cc): resume active conv from ChatDB, not ConvStore (#318)

### DIFF
--- a/internal/controlcenter/chat_service.go
+++ b/internal/controlcenter/chat_service.go
@@ -610,26 +610,50 @@ func (cs *ChatService) ClearActiveSkillsForConv(convID string) {
 }
 
 // CurrentConvID returns the active conversation ID for the CC chat.
-// Priority: in-memory lastChatConv → persisted kv_meta → ConvStore fallback.
+//
+// Priority:
+//  1. in-memory lastChatConv (within this daemon run)
+//  2. persisted kv_meta.active_conv_id — validated against the non-archived
+//     CC conversations list so a stale pointer (e.g. user archived the conv)
+//     doesn't leak through
+//  3. most recent non-archived CC conversation from ChatDB
+//  4. "" — frontend will create a fresh conv
+//
+// This no longer falls back to ConvStore.ConvID. ConvStore IDs are an
+// internal tracking namespace unrelated to the UI's tab IDs, and returning
+// one caused #318 — after a restart with no kv_meta, the server returned
+// a freshly-minted "conv-%x" that the UI couldn't match against its
+// conversation list, rotating the user to a brand-new tab.
 func (cs *ChatService) CurrentConvID() string {
 	if cs.lastChatConv != "" {
 		return cs.lastChatConv
 	}
-	if cs.ChatDB != nil {
-		if v := cs.ChatDB.GetMeta("active_conv_id"); v != "" {
-			return v
+	if cs.ChatDB == nil {
+		return ""
+	}
+	convs, _ := cs.ChatDB.Conversations("cc", false)
+	if v := cs.ChatDB.GetMeta("active_conv_id"); v != "" {
+		for _, c := range convs {
+			if c.ID == v {
+				return v
+			}
 		}
 	}
-	if cs.ConvStore != nil {
-		return cs.ConvStore.ConvID(conversation.ChannelCC)
+	if len(convs) > 0 {
+		return convs[len(convs)-1].ID
 	}
 	return ""
 }
 
 // SetActiveConvID persists the active conversation and updates in-memory state.
+// Also ensures the conv row exists in ChatDB so CurrentConvID's validation
+// (introduced for #318) can resolve it on the next call.
 func (cs *ChatService) SetActiveConvID(convID string) {
 	cs.lastChatConv = convID
 	if cs.ChatDB != nil {
+		if convID != "" {
+			cs.ChatDB.EnsureConversation(convID, "", "cc")
+		}
 		cs.ChatDB.SetMeta("active_conv_id", convID)
 	}
 }

--- a/internal/controlcenter/current_convid_persistence_test.go
+++ b/internal/controlcenter/current_convid_persistence_test.go
@@ -1,0 +1,132 @@
+package controlcenter
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alamparelli/alf/internal/chatdb"
+	"github.com/alamparelli/alf/internal/conversation"
+	"github.com/alamparelli/alf/internal/eventlog"
+	chatsession "github.com/alamparelli/alf/internal/session"
+)
+
+// TestCurrentConvID_ResumesAfterRestart is the regression guard for #318:
+// after a daemon restart, CC's active conversation must be the last one the
+// user was working on, not a freshly-minted ConvStore ID.
+//
+// Simulates: boot, persist a message for conv "tab-A", close stores,
+// re-open from the same dataDir (mimicking daemon restart), and verify
+// CurrentConvID returns "tab-A".
+func TestCurrentConvID_ResumesAfterRestart(t *testing.T) {
+	dataDir := t.TempDir()
+	configDir := t.TempDir()
+	contextDir := filepath.Join(dataDir, "context")
+
+	// --- Boot #1: simulate the daemon running and a user sending a message. ---
+	{
+		chatDB, err := chatdb.New(dataDir)
+		if err != nil {
+			t.Fatalf("chatdb: %v", err)
+		}
+		convStore := conversation.NewStore(dataDir)
+		sessions := chatsession.New(dataDir, 30*time.Minute)
+		evtLog := eventlog.New(dataDir)
+		defer evtLog.Close()
+
+		svc := NewChatService(
+			dataDir, configDir, contextDir,
+			NewFileTierStore(filepath.Join(configDir, "tiers.json")),
+			sessions, evtLog, chatDB, nil,
+			func(string, string, int) RouteResult { return RouteResult{Tier: "test"} },
+			func(s string) string { return s },
+			&mockProvider{},
+		)
+		svc.ConvStore = convStore
+
+		// User's active CC conv and a message.
+		userConvID := "tab-A"
+		chatDB.EnsureConversation(userConvID, "First tab", "cc")
+		chatDB.InsertMessage(chatdb.Message{
+			ID: NewMessageID(), ConvID: userConvID, Role: "user",
+			Text: "hello", Source: "cc", CreatedAt: time.Now(),
+		})
+		svc.SetActiveConvID(userConvID)
+
+		// Also simulate a ConvStore write (the engine would do this).
+		convStore.Append(conversation.Message{
+			ID:        "m1",
+			ConvID:    "convstore-internal-xyz",
+			Channel:   conversation.ChannelCC,
+			Role:      "user",
+			Timestamp: time.Now(),
+		})
+
+		chatDB.Close()
+	}
+
+	// --- Boot #2: same dataDir, fresh ChatService — the "daemon restart". ---
+	chatDB2, err := chatdb.New(dataDir)
+	if err != nil {
+		t.Fatalf("chatdb #2: %v", err)
+	}
+	defer chatDB2.Close()
+
+	convStore2 := conversation.NewStore(dataDir)
+	sessions2 := chatsession.New(dataDir, 30*time.Minute)
+	evtLog2 := eventlog.New(dataDir)
+	defer evtLog2.Close()
+
+	svc2 := NewChatService(
+		dataDir, configDir, contextDir,
+		NewFileTierStore(filepath.Join(configDir, "tiers.json")),
+		sessions2, evtLog2, chatDB2, nil,
+		func(string, string, int) RouteResult { return RouteResult{Tier: "test"} },
+		func(s string) string { return s },
+		&mockProvider{},
+	)
+	svc2.ConvStore = convStore2
+
+	got := svc2.CurrentConvID()
+	if got != "tab-A" {
+		t.Fatalf("CurrentConvID after restart = %q, want %q", got, "tab-A")
+	}
+}
+
+// TestCurrentConvID_FallsBackToLatestConversationOnEmptyMeta guards the
+// case where a fresh user has never triggered SetActiveConvID: the backend
+// should return an ID that actually exists in the conversations list, not
+// a ConvStore internal ID the frontend has no visibility into (#318).
+func TestCurrentConvID_FallsBackToLatestConversationOnEmptyMeta(t *testing.T) {
+	dataDir := t.TempDir()
+	configDir := t.TempDir()
+	contextDir := filepath.Join(dataDir, "context")
+
+	chatDB, err := chatdb.New(dataDir)
+	if err != nil {
+		t.Fatalf("chatdb: %v", err)
+	}
+	defer chatDB.Close()
+	convStore := conversation.NewStore(dataDir)
+	sessions := chatsession.New(dataDir, 30*time.Minute)
+	evtLog := eventlog.New(dataDir)
+	defer evtLog.Close()
+
+	svc := NewChatService(
+		dataDir, configDir, contextDir,
+		NewFileTierStore(filepath.Join(configDir, "tiers.json")),
+		sessions, evtLog, chatDB, nil,
+		func(string, string, int) RouteResult { return RouteResult{Tier: "test"} },
+		func(s string) string { return s },
+		&mockProvider{},
+	)
+	svc.ConvStore = convStore
+
+	// Pre-existing CC conversation but no kv_meta("active_conv_id").
+	chatDB.EnsureConversation("tab-existing", "Existing", "cc")
+
+	got := svc.CurrentConvID()
+	if got != "tab-existing" {
+		t.Fatalf("CurrentConvID = %q, want %q (should fall back to existing CC conv, not ConvStore ID)", got, "tab-existing")
+	}
+}


### PR DESCRIPTION
## Root cause
After a daemon restart, CC rotated to a fresh \`conv-%x\` tab instead of resuming the user's last one.

\`ChatService.CurrentConvID\` fell back to \`ConvStore.ConvID(ChannelCC)\` when \`kv_meta.active_conv_id\` was empty or pointed at a stale conv. **ConvStore IDs live in a separate namespace from the UI's tab IDs** — its fallback never matches any conv in the frontend list, so the UI ended up creating a new tab and \`SetActiveConvID\` persisted it, cementing the rotation.

## Fix
\`CurrentConvID\` resolves in order:
1. in-memory \`lastChatConv\`
2. \`kv_meta.active_conv_id\` **validated** against non-archived CC conversations
3. most recent non-archived CC conv
4. \`\"\"\` (frontend creates one)

\`SetActiveConvID\` now also calls \`EnsureConversation\` so the kv_meta pointer always resolves to a real row.

## Regression tests
- \`TestCurrentConvID_ResumesAfterRestart\` — boots two ChatService instances from the same dataDir (mimicking the daemon restart) and asserts the last user-facing convID comes back.
- \`TestCurrentConvID_FallsBackToLatestConversationOnEmptyMeta\` — guards the fresh-kv_meta path: must pick an existing CC conv, never a ConvStore internal ID. This test **failed** before the fix with \`conv-530869d26225b16a\`, exactly matching the format reported in #318.

## Verification
- \`go test ./...\` — 28 packages green; memstore \`fts5\` pre-existing failure unrelated.
- All prior controlcenter + comms + chatdb tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)