### PR TITLE
fix(chatdb): serialise writers — SetMaxOpenConns(1) (#346)

### DIFF
--- a/internal/chatdb/chatdb.go
+++ b/internal/chatdb/chatdb.go
@@ -159,6 +159,14 @@ func New(dataDir string) (*DB, error) {
 		return nil, fmt.Errorf("chatdb open: %w", err)
 	}
 
+	// SQLite permits one writer at a time. The DSN busy_timeout is a
+	// per-connection pragma and Go's sql pool does not re-apply it on
+	// pool-borrowed connections, so concurrent writers race and fail
+	// with "database is locked" (see #346). Pin the pool to a single
+	// connection — reads are cheap, chatdb is small, and the memory
+	// rework in 0.7.9 moves this behind a single ConvStore anyway.
+	db.SetMaxOpenConns(1)
+
 	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("chatdb WAL: %w", err)
@@ -216,6 +224,9 @@ func (d *DB) EnsureConversation(id, title, source string) error {
 }
 
 // InsertMessage inserts a message along with its content blocks and media in a single transaction.
+// Safe for concurrent use: the pool is pinned to one connection (see New), so
+// concurrent writers are serialised at the sql layer and will not see
+// "database is locked". Callers may assume at-most-one writer at a time.
 func (d *DB) InsertMessage(msg Message) error {
 	if msg.Source == "" {
 		msg.Source = "cc"

--- a/internal/chatdb/chatdb_isolation_test.go
+++ b/internal/chatdb/chatdb_isolation_test.go
@@ -2,7 +2,6 @@ package chatdb
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -289,13 +288,11 @@ func TestDeleteConversation_CascadesMessages(t *testing.T) {
 
 // ----- Concurrent multi-conv writes -----------------------------------
 
-// Concurrent writers across distinct conversations. Today chatdb
-// returns "database is locked" under real concurrency (tracked in
-// #346) because the Go sql pool does not re-apply the busy_timeout
-// pragma to pool-borrowed connections. Callers must retry. This
-// test pins the isolation property — not the concurrency limit.
-// Once #346 lands, the retry loop becomes a no-op; the test still
-// passes, so we do not need to edit it.
+// Concurrent writers across distinct conversations. Pins two
+// properties at once (#346): (1) concurrent InsertMessage returns
+// zero errors — no retry loop — because chatdb now serialises the
+// pool to a single connection; (2) isolation still holds, no
+// cross-conv bleed and seq numbers stay 1..N per conv.
 func TestConcurrentInserts_NoCrossConvBleed(t *testing.T) {
 	db := newTestDB(t)
 	const nConvs = 4
@@ -303,20 +300,6 @@ func TestConcurrentInserts_NoCrossConvBleed(t *testing.T) {
 
 	for i := 0; i < nConvs; i++ {
 		db.EnsureConversation(fmt.Sprintf("c%d", i), "", "cc")
-	}
-
-	insertWithRetry := func(msg Message) error {
-		for attempt := 0; attempt < 50; attempt++ {
-			err := db.InsertMessage(msg)
-			if err == nil {
-				return nil
-			}
-			if !strings.Contains(err.Error(), "locked") {
-				return err
-			}
-			time.Sleep(5 * time.Millisecond)
-		}
-		return fmt.Errorf("still locked after retries")
 	}
 
 	var wg sync.WaitGroup
@@ -327,7 +310,7 @@ func TestConcurrentInserts_NoCrossConvBleed(t *testing.T) {
 			defer wg.Done()
 			convID := fmt.Sprintf("c%d", c)
 			for i := 0; i < nMsgs; i++ {
-				if err := insertWithRetry(Message{
+				if err := db.InsertMessage(Message{
 					ID:     fmt.Sprintf("%s-%d", convID, i),
 					ConvID: convID,
 					Role:   "user",


### PR DESCRIPTION
Closes #346. Unblocks Step 1.2 (#336).

## Summary

- Pin chatdb's sql pool to one connection (`SetMaxOpenConns(1)`).
- Drop the retry loop in `TestConcurrentInserts_NoCrossConvBleed` — concurrent inserts now return zero errors without it.
- Doc on `InsertMessage` now states the serialised contract so the 20+ call sites that currently ignore the return value have an explicit guarantee.

## Why option 1 (and not a connect-hook)

The ticket's own recommendation: simplest, matches SQLite's actual concurrency model, zero risk. The memory rework in 0.7.9 is moving chatdb behind a single `ConvStore` anyway — preserving multi-connection read concurrency here would be premature complexity. Reads remain cheap (SQLite is in-process); what's serialised is the tiny window around writes.

## Acceptance (#346)

- [x] Concurrent `InsertMessage` across ≥ 4 goroutines and ≥ 25 msgs returns zero errors (isolation test now asserts this directly, no retry).
- [x] No cross-conv data bleed (pinned by the existing test).
- [x] `make regression` green.
- [x] Doc on `InsertMessage` updated to reflect the serialised contract (the OR branch of the acceptance — auditing ~20 call sites to check errors was left out of this surgical PR).

## Test plan

- [x] `go test ./internal/chatdb/ -count=3 -race` — isolation test + existing suite, clean.
- [x] `make regression` — green, total 46.8 %.
- [ ] Reviewer sanity: confirm the coverage dip on `internal/chatdb` (56.8 → 56.6 in the aggregate run) is test-ordering drift, not a real loss. Per-function `New()` coverage went up; function-level totals jitter in both directions between runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)