### PR TITLE
fix(controlcenter): drain orchestrator before TempDir cleanup (#347)

### DIFF
--- a/internal/agents/orchestrator.go
+++ b/internal/agents/orchestrator.go
@@ -51,8 +51,9 @@ type Orchestrator struct {
 	toolRegistry    *tooling.Registry   // optional: tool schemas for API agentic loop
 	toolExecutor    *tooling.Executor   // optional: tool subprocess runner
 
-	mu       sync.Mutex
-	running  map[string]*RunningTask
+	mu        sync.Mutex
+	running   map[string]*RunningTask
+	idCounter uint64 // monotonically-increasing suffix for taskID, guarded by mu
 }
 
 // NewOrchestrator creates a new orchestrator.
@@ -81,6 +82,27 @@ func (o *Orchestrator) SetResolveProvider(fn ResolveProviderFunc) {
 func (o *Orchestrator) SetTooling(registry *tooling.Registry, executor *tooling.Executor) {
 	o.toolRegistry = registry
 	o.toolExecutor = executor
+}
+
+// WaitIdle blocks until there are no running tasks, or ctx is cancelled.
+// Used by tests and for clean shutdown to drain in-flight orchestrator
+// goroutines before tearing down their data directory.
+func (o *Orchestrator) WaitIdle(ctx context.Context) error {
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		o.mu.Lock()
+		n := len(o.running)
+		o.mu.Unlock()
+		if n == 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 // Running returns a snapshot of all currently running tasks.
@@ -256,7 +278,13 @@ func (o *Orchestrator) Run(ctx context.Context, userMessage string, systemPrompt
 		teams = allTeams
 	}
 
-	taskID := fmt.Sprintf("%d", time.Now().UnixNano())
+	// Unique taskID: nanosecond timestamp + monotonic counter. UnixNano alone
+	// can collide between concurrent Run() calls scheduled in the same
+	// nanosecond, which would clobber the running map entry. See #347.
+	o.mu.Lock()
+	o.idCounter++
+	taskID := fmt.Sprintf("%d-%d", time.Now().UnixNano(), o.idCounter)
+	o.mu.Unlock()
 	agentsParent := filepath.Join(o.dataDir, "agents")
 	taskDir := filepath.Join(agentsParent, taskID)
 	os.MkdirAll(taskDir, 0o775)

--- a/internal/controlcenter/handler_tasks_test.go
+++ b/internal/controlcenter/handler_tasks_test.go
@@ -43,6 +43,22 @@ func (p *slowProvider) Invoke(ctx context.Context, _ string, _ provider.Params, 
 
 func (p *slowProvider) release() { close(p.gate) }
 
+// waitForRunning blocks until the orchestrator reports at least n running
+// tasks, or the timeout elapses. The handler's fire-and-forget goroutine may
+// not have registered with the orchestrator yet when the HTTP response
+// returns, so callers that need to drain must synchronise on this first.
+func waitForRunning(t *testing.T, orch *agents.Orchestrator, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if len(orch.Running()) >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d running tasks (got %d)", n, len(orch.Running()))
+}
+
 // staticTierStore is a minimal TierStore that returns a fixed config.
 type staticTierStore struct{ cfg *TiersConfig }
 
@@ -155,14 +171,19 @@ func TestTasksHandler_LaunchIsNonBlocking(t *testing.T) {
 		t.Fatal("launch blocked waiting for orchestrator to complete")
 	}
 
-	// Release the provider so the background goroutine can finish cleanly.
+	// Release the provider and drain the orchestrator so TempDir cleanup
+	// doesn't race with background file writes. See #347.
+	waitForRunning(t, orch, 1, 2*time.Second)
 	sp.release()
-	time.Sleep(50 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := orch.WaitIdle(ctx); err != nil {
+		t.Fatalf("orchestrator did not drain: %v", err)
+	}
 }
 
 func TestTasksHandler_ConcurrentTasksRun(t *testing.T) {
 	sp := newSlowProvider()
-	defer sp.release()
 	orch := newTestOrchestrator(t, sp)
 	h := &TasksHandler{Orchestrator: orch, DataDir: t.TempDir(), ContextDir: t.TempDir(), TierStore: newTestTierStore()}
 
@@ -183,12 +204,20 @@ func TestTasksHandler_ConcurrentTasksRun(t *testing.T) {
 	}
 	wg.Wait()
 
-	// All 3 should be tracked as running.
-	// Wait briefly for goroutines to register with orchestrator.
-	time.Sleep(100 * time.Millisecond)
+	// Wait for all 3 goroutines to register with the orchestrator, then assert.
+	waitForRunning(t, orch, 3, 2*time.Second)
 	running := orch.Running()
 	if len(running) < 2 {
 		t.Errorf("expected at least 2 concurrent running tasks, got %d", len(running))
+	}
+
+	// Drain orchestrator goroutines before t.Cleanup removes TempDir, otherwise
+	// post-run meta/log writes race with RemoveAll. See #347.
+	sp.release()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := orch.WaitIdle(ctx); err != nil {
+		t.Fatalf("orchestrator did not drain: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds \`Orchestrator.WaitIdle(ctx)\` so tests (and future clean-shutdown paths) can drain in-flight task goroutines before tearing down their data directory.
- Fixes a secondary bug: concurrent \`Run()\` calls scheduled in the same nanosecond produced identical taskIDs, clobbering the \`running\` map entry. TaskID now includes a monotonic counter guarded by \`o.mu\`.
- Updates \`TestTasksHandler_ConcurrentTasksRun\` + \`TestTasksHandler_LaunchIsNonBlocking\` to wait for tasks to register, release the provider, then drain before returning.

Closes #347.

## Test plan
- [x] \`go test -run 'TestTasksHandler_ConcurrentTasksRun|TestTasksHandler_LaunchIsNonBlocking' -count=20 ./internal/controlcenter/\` → 20/20 pass
- [x] \`make regression-quick\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)