### PR TITLE
refactor(memory): Embedder interface + sqlite-vec Index/Search skeleton (#337 part A)

### DIFF
--- a/internal/memory/embedder.go
+++ b/internal/memory/embedder.go
@@ -1,0 +1,34 @@
+package memory
+
+// Embedder generates vector representations of text for semantic search.
+//
+// Two implementations exist (ported from memstore in #337): an in-process
+// ONNX-backed embedder for offline/isolated runs, and an HTTP client that
+// talks to a dedicated embed-server subprocess. Both satisfy this contract
+// and are interchangeable from the Store's perspective.
+//
+// Dims MUST stay stable across the lifetime of one Store — the vec0 virtual
+// table is created with a fixed dimension at schema time. Swapping embedders
+// with different Dims() requires rebuilding the vec index.
+type Embedder interface {
+	// Embed returns a document embedding for text.
+	Embed(text string) ([]float32, error)
+
+	// EmbedQuery returns a query embedding. Some model families (e.g.
+	// instruction-tuned retrievers) prefix document vs query differently, so
+	// callers MUST use EmbedQuery at Search time and Embed at Index time.
+	EmbedQuery(text string) ([]float32, error)
+
+	// EmbedBatch returns embeddings for a batch of documents. Order must
+	// match the input slice.
+	EmbedBatch(texts []string) ([][]float32, error)
+
+	// IsReady reports whether the embedder can serve requests. The Store
+	// gates vec writes on this — a not-ready embedder falls back to the
+	// non-vector Index/Search path.
+	IsReady() bool
+
+	// Dims returns the embedding dimension. MUST be constant for the
+	// lifetime of the value.
+	Dims() int
+}

--- a/internal/memory/memtest/embedder.go
+++ b/internal/memory/memtest/embedder.go
@@ -1,0 +1,82 @@
+package memtest
+
+import (
+	"hash/fnv"
+	"math"
+
+	"github.com/alamparelli/alf/internal/memory"
+)
+
+// StubEmbedder is a deterministic, fast embedder for unit tests. It maps
+// text to a small vector via hashed-bag-of-words so semantically similar
+// strings (sharing more tokens) yield closer cosine distances, without
+// bringing in ONNX or an HTTP dependency.
+//
+// The output is NOT a semantically meaningful embedding — it only preserves
+// enough structure to exercise Store.Index / Store.Search contracts end to
+// end. Production code MUST NOT import this.
+type StubEmbedder struct {
+	Dim   int
+	Ready bool // when false, IsReady() returns false and the Store falls back to LIKE
+}
+
+// NewStubEmbedder returns a ready-to-use embedder with the given dimension.
+// 16 is plenty for unit tests; production defaults to 384.
+func NewStubEmbedder(dim int) *StubEmbedder {
+	return &StubEmbedder{Dim: dim, Ready: true}
+}
+
+func (e *StubEmbedder) Dims() int    { return e.Dim }
+func (e *StubEmbedder) IsReady() bool { return e.Ready }
+
+func (e *StubEmbedder) Embed(text string) ([]float32, error) {
+	return e.encode(text), nil
+}
+
+func (e *StubEmbedder) EmbedQuery(text string) ([]float32, error) {
+	return e.encode(text), nil
+}
+
+func (e *StubEmbedder) EmbedBatch(texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		out[i] = e.encode(t)
+	}
+	return out, nil
+}
+
+// encode splits on whitespace, hashes each token into a bin, counts, then
+// L2-normalises the bin vector. Cosine similarity on the result rewards
+// shared tokens — good enough to verify the vec path.
+func (e *StubEmbedder) encode(text string) []float32 {
+	v := make([]float32, e.Dim)
+	start := 0
+	for i := 0; i <= len(text); i++ {
+		if i == len(text) || text[i] == ' ' || text[i] == '\t' || text[i] == '\n' {
+			if i > start {
+				h := fnv.New32a()
+				_, _ = h.Write([]byte(text[start:i]))
+				v[int(h.Sum32())%e.Dim] += 1
+			}
+			start = i + 1
+		}
+	}
+	var norm float64
+	for _, f := range v {
+		norm += float64(f) * float64(f)
+	}
+	if norm == 0 {
+		// Keep a non-zero vector so cosine distance stays defined (some vec
+		// backends return NaN for zero-length embeddings).
+		v[0] = 1
+		return v
+	}
+	n := float32(math.Sqrt(norm))
+	for i := range v {
+		v[i] /= n
+	}
+	return v
+}
+
+// compile-time check that StubEmbedder satisfies the interface.
+var _ memory.Embedder = (*StubEmbedder)(nil)

--- a/internal/memory/sqlite.go
+++ b/internal/memory/sqlite.go
@@ -3,9 +3,12 @@ package memory
 import (
 	"context"
 	"database/sql"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,8 +16,16 @@ import (
 	"sync/atomic"
 	"time"
 
+	sqlite_vec "github.com/asg017/sqlite-vec-go-bindings/cgo"
 	_ "github.com/mattn/go-sqlite3"
 )
+
+func init() {
+	// Register the sqlite-vec extension on every sqlite3 connection opened
+	// after this point. Safe to call from multiple packages — it's
+	// idempotent in sqlite_vec/cgo.
+	sqlite_vec.Auto()
+}
 
 // SQLiteStore is the production Store backend for Step 1.2 (#336). It
 // absorbs the old chatdb + conversation packages under one SQLite database
@@ -30,11 +41,41 @@ type SQLiteStore struct {
 	db     *sql.DB
 	msgSeq atomic.Uint64
 
+	// Optional embedding pipeline. When nil, Index/Search use the legacy
+	// LIKE substring path; when set, Index also stores a float[dim] vector
+	// in the documents_vec virtual table and Search uses cosine similarity.
+	embedder Embedder
+	embedDim int // cached Dims() at open time; 0 means vec disabled
+
 	// nowFn is the injectable clock. Defaults to time.Now().UnixMilli.
 	// Exposed only for tests in the same package.
 	nowFn func() int64
 
 	closeOnce sync.Once
+}
+
+// StoreOption configures a SQLiteStore at construction time.
+//
+// Options are applied in order and MUST only touch fields of the store —
+// the schema is materialised after options run so an option may opt into
+// features (e.g. vector search) that depend on extra tables.
+type StoreOption func(*SQLiteStore)
+
+// WithEmbedder enables semantic Index/Search backed by sqlite-vec. The
+// embedder's Dims() must be non-zero; passing an embedder with Dims() == 0
+// is treated as "no embedder" and the store falls back to the LIKE path.
+//
+// Swapping embedder implementations between runs is allowed as long as
+// Dims() stays the same — the vec0 virtual table is created with a fixed
+// dimension and SQLite does not let you alter that in place.
+func WithEmbedder(e Embedder) StoreOption {
+	return func(s *SQLiteStore) {
+		if e == nil || e.Dims() <= 0 {
+			return
+		}
+		s.embedder = e
+		s.embedDim = e.Dims()
+	}
 }
 
 const sqliteSchema = `
@@ -126,7 +167,12 @@ CREATE TABLE IF NOT EXISTS prefs (
 //
 // Pass an empty dataDir to use an in-memory SQLite DB (":memory:") — intended
 // for tests only. Production callers always pass a real directory.
-func NewSQLiteStore(dataDir string) (*SQLiteStore, error) {
+//
+// Options configure optional subsystems. WithEmbedder enables semantic
+// search — the vec0 / FTS5 tables are materialised only when an embedder
+// is present so the default-path schema stays CGO-vec-free for callers
+// that don't need it.
+func NewSQLiteStore(dataDir string, opts ...StoreOption) (*SQLiteStore, error) {
 	var dbPath string
 	if dataDir == "" {
 		dbPath = ":memory:"
@@ -159,6 +205,15 @@ func NewSQLiteStore(dataDir string) (*SQLiteStore, error) {
 		db:    db,
 		nowFn: func() int64 { return time.Now().UnixMilli() },
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.embedDim > 0 {
+		if err := s.migrateVecSchema(); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("memory: vec schema: %w", err)
+		}
+	}
 
 	// Seed the in-process sequence from the highest existing message ID so
 	// reopening a DB does not collide with old IDs.
@@ -171,6 +226,80 @@ func NewSQLiteStore(dataDir string) (*SQLiteStore, error) {
 	}
 
 	return s, nil
+}
+
+// migrateVecSchema adds the vec0 + FTS5 tables used for semantic Search.
+// Called only when an embedder is configured; the default schema stays
+// vec-free so callers that don't need semantic search pay no CGO-vec cost
+// at open time.
+//
+// The documents table owns an INTEGER rowid (implicit in SQLite); we use
+// that rowid as the join key for both virtual tables. The vec dimension is
+// baked into the DDL — swapping embedders with a different dim requires
+// dropping and rebuilding the index (handled in a later sub-ticket).
+func (s *SQLiteStore) migrateVecSchema() error {
+	// Idempotency: record the dim the index was created with and refuse to
+	// reopen with a different one. Matches the memstore invariant — vec0
+	// cannot change its declared dimension in place.
+	if _, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS doc_vec_meta (
+		key   TEXT PRIMARY KEY,
+		value TEXT NOT NULL
+	)`); err != nil {
+		return fmt.Errorf("doc_vec_meta: %w", err)
+	}
+	var existingDim string
+	_ = s.db.QueryRow(`SELECT value FROM doc_vec_meta WHERE key = 'dim'`).Scan(&existingDim)
+	if existingDim != "" && existingDim != fmt.Sprintf("%d", s.embedDim) {
+		return fmt.Errorf("memory: vec dim mismatch: db was built with %s, embedder reports %d", existingDim, s.embedDim)
+	}
+	if existingDim == "" {
+		if _, err := s.db.Exec(`INSERT INTO doc_vec_meta (key, value) VALUES ('dim', ?)`, fmt.Sprintf("%d", s.embedDim)); err != nil {
+			return fmt.Errorf("doc_vec_meta insert: %w", err)
+		}
+	}
+
+	stmts := []string{
+		fmt.Sprintf(`CREATE VIRTUAL TABLE IF NOT EXISTS documents_vec USING vec0(
+			rowid INTEGER PRIMARY KEY,
+			embedding float[%d] distance_metric=cosine
+		)`, s.embedDim),
+		`CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
+			text, scope UNINDEXED, content=documents, content_rowid=rowid
+		)`,
+		// Keep FTS5 mirror in sync with documents. vec0 is written
+		// explicitly by Index() — we don't trigger it from SQL because the
+		// embedding must be computed in Go.
+		`CREATE TRIGGER IF NOT EXISTS documents_ai AFTER INSERT ON documents BEGIN
+			INSERT INTO documents_fts(rowid, text, scope) VALUES (new.rowid, new.text, new.scope);
+		END`,
+		`CREATE TRIGGER IF NOT EXISTS documents_ad AFTER DELETE ON documents BEGIN
+			INSERT INTO documents_fts(documents_fts, rowid, text, scope) VALUES('delete', old.rowid, old.text, old.scope);
+		END`,
+		`CREATE TRIGGER IF NOT EXISTS documents_au AFTER UPDATE ON documents BEGIN
+			INSERT INTO documents_fts(documents_fts, rowid, text, scope) VALUES('delete', old.rowid, old.text, old.scope);
+			INSERT INTO documents_fts(rowid, text, scope) VALUES (new.rowid, new.text, new.scope);
+		END`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.Exec(stmt); err != nil {
+			head := stmt
+			if len(head) > 80 {
+				head = head[:80]
+			}
+			return fmt.Errorf("exec %q: %w", head, err)
+		}
+	}
+	return nil
+}
+
+// serializeVec converts a float32 vector into the little-endian byte blob
+// that sqlite-vec expects for a vec0 column.
+func serializeVec(v []float32) []byte {
+	buf := make([]byte, 4*len(v))
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(f))
+	}
+	return buf
 }
 
 // Close releases the database handle. Safe to call multiple times.
@@ -894,7 +1023,7 @@ func (s *SQLiteStore) Index(ctx context.Context, scope Scope, doc Document) erro
 		}
 		meta = string(b)
 	}
-	_, err := s.db.ExecContext(ctx, `
+	res, err := s.db.ExecContext(ctx, `
 		INSERT INTO documents (scope, doc_id, text, metadata, inserted_at)
 		VALUES (?, ?, ?, ?, ?)
 		ON CONFLICT(scope, doc_id) DO UPDATE SET
@@ -902,7 +1031,48 @@ func (s *SQLiteStore) Index(ctx context.Context, scope Scope, doc Document) erro
 		    metadata = excluded.metadata,
 		    inserted_at = excluded.inserted_at`,
 		string(scope), doc.ID, doc.Text, meta, s.nowFn())
-	return err
+	if err != nil {
+		return err
+	}
+
+	if s.embedder == nil || !s.embedder.IsReady() {
+		return nil
+	}
+
+	// Resolve the document's rowid — the INSERT…ON CONFLICT path returns
+	// LastInsertId only on the insert branch, so for upserts we re-query.
+	rowID, lidErr := res.LastInsertId()
+	if lidErr != nil || rowID == 0 {
+		if err := s.db.QueryRowContext(ctx,
+			`SELECT rowid FROM documents WHERE scope = ? AND doc_id = ?`,
+			string(scope), doc.ID).Scan(&rowID); err != nil {
+			return fmt.Errorf("memory: Index: rowid lookup: %w", err)
+		}
+	}
+
+	vec, embErr := s.embedder.Embed(doc.Text)
+	if embErr != nil {
+		// Embedding failure is non-fatal — the row is still in documents
+		// and FTS5; only the vec path is degraded. Callers see reduced
+		// semantic quality rather than a hard error. Logged for ops.
+		log.Printf("[memory] Index: embed failed (scope=%q id=%q): %v — vec skipped", scope, doc.ID, embErr)
+		return nil
+	}
+	if len(vec) != s.embedDim {
+		return fmt.Errorf("memory: Index: embedder returned %d dims, expected %d", len(vec), s.embedDim)
+	}
+
+	// UPSERT into vec0: delete old row (if any) then insert. vec0 does not
+	// support ON CONFLICT.
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM documents_vec WHERE rowid = ?`, rowID); err != nil {
+		return fmt.Errorf("memory: Index: vec delete: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO documents_vec (rowid, embedding) VALUES (?, ?)`,
+		rowID, serializeVec(vec)); err != nil {
+		return fmt.Errorf("memory: Index: vec insert: %w", err)
+	}
+	return nil
 }
 
 func (s *SQLiteStore) Search(ctx context.Context, scope Scope, query string, k int) ([]Hit, error) {
@@ -916,8 +1086,19 @@ func (s *SQLiteStore) Search(ctx context.Context, scope Scope, query string, k i
 		return nil, nil
 	}
 
-	// LIKE-based substring match — same pragma as InMem. The Step 1.3 work
-	// replaces this with the FTS5 path inherited from memstore.
+	// Vector path: embed the query, ask sqlite-vec for nearest neighbours
+	// scoped to the requested Scope, then map back to Documents.
+	if s.embedder != nil && s.embedder.IsReady() && strings.TrimSpace(query) != "" {
+		if hits, err := s.searchVec(ctx, scope, query, k); err != nil {
+			log.Printf("[memory] Search: vec path failed, falling back to LIKE: %v", err)
+		} else {
+			return hits, nil
+		}
+	}
+
+	// LIKE substring fallback — used when no embedder is configured, the
+	// embedder is not ready, or the query is empty. Kept so tests and
+	// bootstrap runs without a model continue to work.
 	q := query
 	lower := strings.ToLower(q)
 
@@ -985,6 +1166,73 @@ func scoredLess(a, b struct {
 		return a.hit.Score > b.hit.Score
 	}
 	return a.idx < b.idx
+}
+
+// searchVec runs a cosine-distance nearest-neighbour lookup over documents_vec
+// and returns the matching Documents. Restricted to the requested scope — we
+// over-fetch (k * 4, capped) from vec0 and filter post-hoc because sqlite-vec
+// does not expose a SQL WHERE clause on the index itself.
+func (s *SQLiteStore) searchVec(ctx context.Context, scope Scope, query string, k int) ([]Hit, error) {
+	qv, err := s.embedder.EmbedQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("embed query: %w", err)
+	}
+	if len(qv) != s.embedDim {
+		return nil, fmt.Errorf("embedder returned %d dims, expected %d", len(qv), s.embedDim)
+	}
+
+	// Over-fetch to absorb the per-scope filter. 4x is a heuristic — same
+	// ballpark as memstore. Capped so we don't pull the whole index if a
+	// caller asks for k=10000.
+	fetch := k * 4
+	if fetch < 32 {
+		fetch = 32
+	}
+	if fetch > 1024 {
+		fetch = 1024
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT d.doc_id, d.text, d.metadata, v.distance
+		FROM documents_vec v
+		JOIN documents d ON d.rowid = v.rowid
+		WHERE v.embedding MATCH ? AND d.scope = ? AND k = ?
+		ORDER BY v.distance ASC`,
+		serializeVec(qv), string(scope), fetch)
+	if err != nil {
+		return nil, fmt.Errorf("vec query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Hit
+	for rows.Next() {
+		var d Document
+		var meta string
+		var dist float64
+		if err := rows.Scan(&d.ID, &d.Text, &meta, &dist); err != nil {
+			return nil, err
+		}
+		if meta != "" && meta != "{}" {
+			_ = json.Unmarshal([]byte(meta), &d.Metadata)
+		}
+		// Cosine distance → similarity score in [0, 1] (higher == more
+		// relevant), matching the contract on Hit.Score.
+		score := float32(1.0 - dist)
+		if score < 0 {
+			score = 0
+		}
+		out = append(out, Hit{Document: d, Score: score})
+		if len(out) >= k {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
 }
 
 // Preferences ---------------------------------------------------------------

--- a/internal/memory/sqlitevec_test.go
+++ b/internal/memory/sqlitevec_test.go
@@ -1,0 +1,145 @@
+package memory_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/alamparelli/alf/internal/memory"
+	"github.com/alamparelli/alf/internal/memory/memtest"
+)
+
+// TestSQLiteStore_VecSearch_ReturnsClosestMatch verifies the semantic
+// Search path: with an embedder wired, Search should rank documents by
+// vector similarity and return the closest-matching doc first.
+func TestSQLiteStore_VecSearch_ReturnsClosestMatch(t *testing.T) {
+	emb := memtest.NewStubEmbedder(32)
+	s, err := memory.NewSQLiteStore(t.TempDir(), memory.WithEmbedder(emb))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	docs := []memory.Document{
+		{ID: "a", Text: "the cat sat on the mat"},
+		{ID: "b", Text: "quantum entanglement and superposition"},
+		{ID: "c", Text: "a dog ran across the yard"},
+	}
+	for _, d := range docs {
+		if err := s.Index(ctx, "test", d); err != nil {
+			t.Fatalf("Index %q: %v", d.ID, err)
+		}
+	}
+
+	hits, err := s.Search(ctx, "test", "cat mat", 2)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatalf("Search returned no hits")
+	}
+	if hits[0].Document.ID != "a" {
+		t.Errorf("expected top hit = 'a' (exact token overlap), got %q (score=%f)", hits[0].Document.ID, hits[0].Score)
+	}
+}
+
+// TestSQLiteStore_VecSearch_ScopeIsolation verifies that Search only
+// returns docs indexed under the requested scope, even when other scopes
+// contain a better vector match.
+func TestSQLiteStore_VecSearch_ScopeIsolation(t *testing.T) {
+	emb := memtest.NewStubEmbedder(32)
+	s, err := memory.NewSQLiteStore(t.TempDir(), memory.WithEmbedder(emb))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	if err := s.Index(ctx, "scopeA", memory.Document{ID: "1", Text: "alpha beta gamma"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Index(ctx, "scopeB", memory.Document{ID: "2", Text: "alpha beta gamma"}); err != nil {
+		t.Fatal(err)
+	}
+
+	hits, err := s.Search(ctx, "scopeA", "alpha beta", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if h.Document.ID != "1" {
+			t.Errorf("scopeA search leaked doc %q from another scope", h.Document.ID)
+		}
+	}
+}
+
+// TestSQLiteStore_VecIndex_UpdatesReplaceVector verifies re-indexing the
+// same (scope, doc_id) refreshes the vector rather than stacking two rows.
+func TestSQLiteStore_VecIndex_UpdatesReplaceVector(t *testing.T) {
+	emb := memtest.NewStubEmbedder(32)
+	s, err := memory.NewSQLiteStore(t.TempDir(), memory.WithEmbedder(emb))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	_ = s.Index(ctx, "s", memory.Document{ID: "x", Text: "first version about oranges"})
+	_ = s.Index(ctx, "s", memory.Document{ID: "x", Text: "replacement about apples"})
+
+	hits, err := s.Search(ctx, "s", "apples", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly 1 hit after re-index, got %d", len(hits))
+	}
+	if !strings.Contains(hits[0].Document.Text, "apples") {
+		t.Errorf("expected updated text, got %q", hits[0].Document.Text)
+	}
+}
+
+// TestSQLiteStore_NoEmbedder_FallsBackToLike guards the backwards-compatible
+// path: callers that don't pass WithEmbedder still get a working Search via
+// the LIKE fallback — critical for tests and bootstrap runs.
+func TestSQLiteStore_NoEmbedder_FallsBackToLike(t *testing.T) {
+	s, err := memory.NewSQLiteStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	_ = s.Index(ctx, "s", memory.Document{ID: "1", Text: "needle in a haystack"})
+	_ = s.Index(ctx, "s", memory.Document{ID: "2", Text: "unrelated content"})
+
+	hits, err := s.Search(ctx, "s", "needle", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || hits[0].Document.ID != "1" {
+		t.Errorf("LIKE fallback: expected single hit id=1, got %+v", hits)
+	}
+}
+
+// TestSQLiteStore_VecDim_PersistsAcrossOpens catches the schema-drift
+// failure mode where a store is re-opened with an embedder of a different
+// dimension. The second open must fail fast rather than silently corrupting
+// the vec index.
+func TestSQLiteStore_VecDim_PersistsAcrossOpens(t *testing.T) {
+	dir := t.TempDir()
+	s1, err := memory.NewSQLiteStore(dir, memory.WithEmbedder(memtest.NewStubEmbedder(16)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s1.Close()
+
+	_, err = memory.NewSQLiteStore(dir, memory.WithEmbedder(memtest.NewStubEmbedder(32)))
+	if err == nil {
+		t.Fatalf("expected dim-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "dim mismatch") {
+		t.Errorf("expected dim mismatch error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Step 1.3 sub-part A — lands the semantic-search foundation in the \`memory\` package so upcoming sub-tickets can migrate \`memstore\` callers without also porting the SQL layer.

- New \`memory.Embedder\` interface (mirror of \`memstore.EmbedderI\`).
- \`WithEmbedder\` option on \`NewSQLiteStore\`; when set, materialises \`documents_vec\` (vec0 cosine) + \`documents_fts\` (FTS5) and their sync triggers.
- \`Index\` embeds and upserts into the vec table when an embedder is ready.
- \`Search\` uses cosine NN when embedder is ready; falls back to LIKE otherwise.
- \`doc_vec_meta\` persists the embedding dim so re-opening with a different dim fails fast instead of silently corrupting the index.
- \`memtest.StubEmbedder\` — deterministic hashed-BOW embedder for unit tests (no ONNX, no network).

## Scope
**In**: interface, schema, Index/Search rewiring, tests.
**Out**: porting \`memstore.Embedder\` / \`memstore.HTTPEmbedder\` (sub-ticket B), migrating callers off \`*memstore.Store\` (sub-ticket B), retiring \`memstore\` package (sub-ticket C).

No caller migration: existing callers of \`NewSQLiteStore(dataDir)\` keep working unchanged (LIKE fallback preserved).

Part of #337.

## Test plan
- [x] \`go test -tags fts5 -run 'TestSQLiteStore_Vec|TestSQLiteStore_NoEmbedder' -v ./internal/memory/\` → 5/5 pass (ranking, scope isolation, re-index replaces vector, LIKE fallback, dim mismatch).
- [x] \`make regression-quick\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)