### PR TITLE
refactor(memory): port HTTPEmbedder + wire semantic search (#337 part B)

### DIFF
--- a/cmd/alf-daemon/main.go
+++ b/cmd/alf-daemon/main.go
@@ -429,18 +429,23 @@ func main() {
 		log.Println("voice transcription disabled (WHISPER_URL or WHISPER_SHARED_SECRET not set)")
 	}
 
-	// Embedding engine: resolve from tier config or EMBED_URL env (sidecar container).
-	var memDB *memstore.Store
-	if !cfg.EffectiveMemoryEnabled() {
-		log.Println("memstore: disabled by config (memory_enabled=false)")
-	} else {
-		embedder := resolveEmbedder(tierStore)
+	// Embedding engine: resolve once and share between the legacy memstore
+	// (cmd/alf-daemon-side semantic memory) and the unified memory.Store
+	// (opened below). Both paths consult the same HTTP embed-server.
+	var embedder memory.Embedder
+	if cfg.EffectiveMemoryEnabled() {
+		embedder = resolveEmbedder(tierStore)
 		if embedder != nil {
 			if stopper, ok := embedder.(interface{ Stop() }); ok {
 				defer stopper.Stop()
 			}
 		}
+	}
 
+	var memDB *memstore.Store
+	if !cfg.EffectiveMemoryEnabled() {
+		log.Println("memstore: disabled by config (memory_enabled=false)")
+	} else {
 		dedupCfg := memstore.DedupConfig{
 			TextThreshold:   cfg.EffectiveMemoryDedupTextThreshold(),
 			CosineThreshold: cfg.EffectiveMemoryDedupCosineThreshold(),
@@ -471,7 +476,11 @@ func main() {
 	if err := migrateChatDBToMemoryDB(dataDir); err != nil {
 		log.Fatalf("memory migration: %v", err)
 	}
-	memStore, err := memory.NewSQLiteStore(dataDir)
+	var memOpts []memory.StoreOption
+	if embedder != nil {
+		memOpts = append(memOpts, memory.WithEmbedder(embedder))
+	}
+	memStore, err := memory.NewSQLiteStore(dataDir, memOpts...)
 	if err != nil {
 		log.Fatalf("memory: %v", err)
 	}
@@ -2137,7 +2146,7 @@ func refreshTelegramCommands(tg *tgclient.Client, tierStore cc.TierStore) {
 
 // resolveEmbedder picks the best available embedder implementation.
 // Priority: 1) tier profile memory.embedding, 2) legacy tier embedding, 3) EMBED_URL env, 4) nil (FTS5-only).
-func resolveEmbedder(tierStore cc.TierStore) memstore.EmbedderI {
+func resolveEmbedder(tierStore cc.TierStore) memory.Embedder {
 	// Use a stable instance ID so re-registrations reuse the same slot in the
 	// embed-server token map. Docker hostnames change on every container restart,
 	// which would leak slots and eventually hit the 50-instance cap.
@@ -2147,14 +2156,14 @@ func resolveEmbedder(tierStore cc.TierStore) memstore.EmbedderI {
 	if tc := tierStore.Current(); tc != nil {
 		// 1. New: memory.embedding config.
 		if tc.Memory != nil && tc.Memory.Embedding != nil && tc.Memory.Embedding.URL != "" {
-			emb := memstore.NewHTTPEmbedder(tc.Memory.Embedding.URL, embedInstanceID, secret, 30*time.Second)
+			emb := memory.NewHTTPEmbedder(tc.Memory.Embedding.URL, embedInstanceID, secret, 30*time.Second)
 			go startHTTPEmbedder(emb)
 			log.Printf("memstore: using HTTP embedder from memory config (url=%s)", tc.Memory.Embedding.URL)
 			return emb
 		}
 		// 2. Legacy: embedding config at tier root (backward compat).
 		if tc.Embedding != nil && tc.Embedding.URL != "" {
-			emb := memstore.NewHTTPEmbedder(tc.Embedding.URL, embedInstanceID, secret, 30*time.Second)
+			emb := memory.NewHTTPEmbedder(tc.Embedding.URL, embedInstanceID, secret, 30*time.Second)
 			go startHTTPEmbedder(emb)
 			log.Printf("memstore: using HTTP embedder from tier config (url=%s)", tc.Embedding.URL)
 			return emb
@@ -2163,7 +2172,7 @@ func resolveEmbedder(tierStore cc.TierStore) memstore.EmbedderI {
 
 	// 2. From env var (embed sidecar container, same pattern as whisper).
 	if url := os.Getenv("EMBED_URL"); url != "" {
-		emb := memstore.NewHTTPEmbedder(url, embedInstanceID, secret, 30*time.Second)
+		emb := memory.NewHTTPEmbedder(url, embedInstanceID, secret, 30*time.Second)
 		go startHTTPEmbedder(emb)
 		log.Printf("memstore: using HTTP embedder (url=%s)", url)
 		return emb
@@ -2177,7 +2186,7 @@ func resolveEmbedder(tierStore cc.TierStore) memstore.EmbedderI {
 // startHTTPEmbedder registers with the embed service, retrying up to 30 times.
 // Falls back to FTS5-only search if embed service is unavailable.
 // Gives up early on "no route to host" / "connection refused" (service not deployed).
-func startHTTPEmbedder(emb *memstore.HTTPEmbedder) {
+func startHTTPEmbedder(emb *memory.HTTPEmbedder) {
 	for attempt := 1; attempt <= 30; attempt++ {
 		err := emb.Start()
 		if err == nil {

--- a/internal/memory/http_embedder.go
+++ b/internal/memory/http_embedder.go
@@ -1,4 +1,4 @@
-package memstore
+package memory
 
 import (
 	"bytes"

--- a/internal/memory/http_embedder_test.go
+++ b/internal/memory/http_embedder_test.go
@@ -1,4 +1,4 @@
-package memstore
+package memory
 
 import (
 	"encoding/json"
@@ -304,8 +304,8 @@ func TestHTTPEmbedderStop(t *testing.T) {
 }
 
 func TestHTTPEmbedderInterfaceCompliance(t *testing.T) {
-	// Compile-time check that HTTPEmbedder satisfies EmbedderI.
-	var _ EmbedderI = (*HTTPEmbedder)(nil)
+	// Compile-time check that HTTPEmbedder satisfies the Embedder contract.
+	var _ Embedder = (*HTTPEmbedder)(nil)
 }
 
 func TestHTTPEmbedderIdempotentStart(t *testing.T) {

--- a/internal/memstore/embedder_iface.go
+++ b/internal/memstore/embedder_iface.go
@@ -1,15 +1,27 @@
 package memstore
 
-// EmbedderI abstracts embedding generation for semantic memory search.
-// Implementations: *Embedder (in-process ONNX) and *HTTPEmbedder (remote HTTP service).
-type EmbedderI interface {
-	Embed(text string) ([]float32, error)
-	EmbedQuery(text string) ([]float32, error)
-	EmbedBatch(texts []string) ([][]float32, error)
-	IsReady() bool
-	Dims() int
+import (
+	"time"
+
+	"github.com/alamparelli/alf/internal/memory"
+)
+
+// EmbedderI is kept as an alias of memory.Embedder during the Step 1.3
+// transition (#337). Existing memstore code and callers continue to
+// compile unchanged; new code should reference memory.Embedder directly.
+// This alias will be removed once memstore itself is retired.
+type EmbedderI = memory.Embedder
+
+// HTTPEmbedder moved to the memory package in #337 — kept as an alias so
+// in-flight callers compile without churn. Prefer memory.HTTPEmbedder in
+// new code.
+type HTTPEmbedder = memory.HTTPEmbedder
+
+// NewHTTPEmbedder is re-exported for the same reason. Direct call site:
+// memory.NewHTTPEmbedder.
+func NewHTTPEmbedder(baseURL, instanceID, secret string, timeout time.Duration) *HTTPEmbedder {
+	return memory.NewHTTPEmbedder(baseURL, instanceID, secret, timeout)
 }
 
-// Compile-time interface compliance.
+// Compile-time interface compliance for the in-process ONNX embedder.
 var _ EmbedderI = (*Embedder)(nil)
-var _ EmbedderI = (*HTTPEmbedder)(nil)


### PR DESCRIPTION
## Summary
Step 1.3 sub-part B — moves the HTTPEmbedder out of memstore and wires the same embedder instance into \`memory.NewSQLiteStore\` so \`memory.Search\` uses the vec0/FTS5 path in production.

- \`internal/memstore/http_embedder{,_test}.go\` → \`internal/memory/\` (package rename only; implementation unchanged).
- \`memstore.EmbedderI\`, \`memstore.HTTPEmbedder\`, \`memstore.NewHTTPEmbedder\` kept as thin aliases over the memory types so in-flight memstore code still compiles. Aliases retire with memstore in sub-ticket C.
- Daemon bootstrap resolves the embedder once at a shared scope and passes it to both \`memstore.New\` and \`memory.NewSQLiteStore(dataDir, memory.WithEmbedder(emb))\`. Gating stays on \`cfg.EffectiveMemoryEnabled()\`.
- \`resolveEmbedder\` / \`startHTTPEmbedder\` now reference \`memory.Embedder\` / \`*memory.HTTPEmbedder\` directly.

Result: \`memory.Store\` has live semantic search in production. No caller migration off \`*memstore.Store\` yet — that's sub-ticket C.

Part of #337.

## Test plan
- [x] \`make regression-quick\` green.
- [x] \`go test -tags fts5 ./internal/memory/ ./internal/memstore/ ./cmd/alf-daemon/\` — all pass including ported HTTPEmbedder tests and the existing vec tests from part A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)