### PR TITLE
refactor(memstore): dual-write into memory.Store.Index (#337 part C1)

### DIFF
--- a/cmd/alf-daemon/main.go
+++ b/cmd/alf-daemon/main.go
@@ -486,6 +486,14 @@ func main() {
 	}
 	defer memStore.Close()
 
+	// Dual-write shim for #337c1: every memstore.Store write also lands in
+	// memory.Store as an Index(scope=type, id=fmt.Sprint(memID)). Lets the
+	// unified store fill up as the extractor runs, without moving any
+	// reader off memstore yet. The reader migration is sub-ticket C2.
+	if memDB != nil {
+		memDB.SetMirror(memStore)
+	}
+
 	// Provider: spawn-per-call Claude CLI for responses.
 	// Process isolation: daemon runs as alfd (uid 1001), subprocess runs as alf (uid 1000).
 	alfCred := &syscall.Credential{Uid: 1000, Gid: 1000}

--- a/internal/memstore/mirror_test.go
+++ b/internal/memstore/mirror_test.go
@@ -1,0 +1,104 @@
+package memstore_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/alamparelli/alf/internal/memory"
+	"github.com/alamparelli/alf/internal/memstore"
+)
+
+// TestStore_SetMirror_ForwardsWrites verifies that once SetMirror has been
+// called, every successful memstore.Store.Store() also lands in the
+// memory.Store as an Index call under the corresponding scope.
+//
+// Dual-write is the #337c1 transition path: writers keep using memstore
+// while the unified memory.db fills up with the same facts, so readers
+// (sub-ticket C2) can migrate without losing data.
+func TestStore_SetMirror_ForwardsWrites(t *testing.T) {
+	mirror, err := memory.NewSQLiteStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewSQLiteStore: %v", err)
+	}
+	defer mirror.Close()
+
+	dbPath := filepath.Join(t.TempDir(), "memstore.db")
+	s, err := memstore.New(dbPath, nil)
+	if err != nil {
+		t.Fatalf("memstore.New: %v", err)
+	}
+	defer s.Close()
+
+	s.SetMirror(mirror)
+
+	id, err := s.Store("the cat sat on the mat", "fact", "extractor", nil)
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("expected non-zero id")
+	}
+
+	// Read back from the mirror — memory.Store with no embedder uses LIKE,
+	// so the query must be a contiguous substring of the stored text.
+	hits, err := mirror.Search(context.Background(), "fact", "cat sat", 5)
+	if err != nil {
+		t.Fatalf("mirror.Search: %v", err)
+	}
+	found := false
+	for _, h := range hits {
+		if h.Document.Text == "the cat sat on the mat" {
+			found = true
+			if h.Document.Metadata["source"] != "extractor" {
+				t.Errorf("mirror dropped source metadata: got %q", h.Document.Metadata["source"])
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("mirror did not receive the write; got hits=%+v", hits)
+	}
+}
+
+// TestStore_SetMirror_ScopeIsMemType verifies the mirror uses the memstore
+// memType as the memory.Scope — so a "preference" write goes into scope
+// "preference", not "fact". Readers depend on this to query the right
+// scope post-migration.
+func TestStore_SetMirror_ScopeIsMemType(t *testing.T) {
+	mirror, err := memory.NewSQLiteStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mirror.Close()
+
+	s, err := memstore.New(filepath.Join(t.TempDir(), "m.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	s.SetMirror(mirror)
+
+	if _, err := s.Store("user prefers dark mode", "preference", "extractor", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Store("project uses Go 1.24", "fact", "extractor", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	prefHits, _ := mirror.Search(context.Background(), "preference", "dark mode", 5)
+	if len(prefHits) == 0 {
+		t.Errorf("preference not mirrored into scope='preference'")
+	}
+	factHits, _ := mirror.Search(context.Background(), "fact", "Go 1.24", 5)
+	if len(factHits) == 0 {
+		t.Errorf("fact not mirrored into scope='fact'")
+	}
+	// Cross-scope leak check: the preference must NOT be in scope='fact'.
+	leakHits, _ := mirror.Search(context.Background(), "fact", "dark mode", 5)
+	for _, h := range leakHits {
+		if h.Document.Text == "user prefers dark mode" {
+			t.Errorf("preference leaked into scope='fact'")
+		}
+	}
+}

--- a/internal/memstore/store.go
+++ b/internal/memstore/store.go
@@ -1,6 +1,7 @@
 package memstore
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -12,6 +13,8 @@ import (
 
 	sqlite_vec "github.com/asg017/sqlite-vec-go-bindings/cgo"
 	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/alamparelli/alf/internal/memory"
 )
 
 func init() {
@@ -41,6 +44,23 @@ type Store struct {
 	embedder EmbedderI
 	dedup    atomic.Value // DedupConfig, swappable at runtime (hot reload)
 	mu       sync.RWMutex
+
+	// mirror is an optional memory.Store that receives an Index(scope=type,
+	// doc_id=fmt.Sprint(id)) call for every successful Store() during the
+	// #337 transition. Lets the unified memory.db fill up as the extractor
+	// runs without moving writers off memstore yet. Read under mu.
+	mirror memory.Store
+}
+
+// SetMirror wires a memory.Store as a dual-write target. After SetMirror,
+// every successful Store() also issues memory.Store.Index using the memory
+// type as Scope and the freshly-assigned id as Document.ID. Mirror errors
+// are logged and swallowed — a mirror failure MUST NOT fail the primary
+// write (the whole point is a non-intrusive shadow during #337).
+func (s *Store) SetMirror(m memory.Store) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mirror = m
 }
 
 // dedupCfg returns the current dedup config (lock-free read).
@@ -167,10 +187,10 @@ func (s *Store) migrate() error {
 // Deduplicates by checking FTS5 for near-exact matches first.
 func (s *Store) Store(text, memType, source string, meta map[string]any) (int64, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	// Dedup: check for near-exact match via FTS5.
 	if s.hasDuplicate(text) {
+		s.mu.Unlock()
 		return 0, fmt.Errorf("duplicate memory detected")
 	}
 
@@ -185,6 +205,7 @@ func (s *Store) Store(text, memType, source string, meta map[string]any) (int64,
 		text, memType, source, string(metaJSON), now,
 	)
 	if err != nil {
+		s.mu.Unlock()
 		return 0, fmt.Errorf("insert memory: %w", err)
 	}
 
@@ -203,6 +224,29 @@ func (s *Store) Store(text, memType, source string, meta map[string]any) (int64,
 			); err != nil {
 				log.Printf("memstore: vec insert failed for memory #%d: %v", id, err)
 			}
+		}
+	}
+
+	mirror := s.mirror
+	s.mu.Unlock()
+
+	// Dual-write into memory.Store (#337 transition). Runs outside s.mu so a
+	// slow embed call on the shared embedder cannot stall memstore writers.
+	// Failures are best-effort — the primary memstore write has already
+	// succeeded.
+	if mirror != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		indexErr := mirror.Index(ctx, memory.Scope(memType), memory.Document{
+			ID:   fmt.Sprintf("%d", id),
+			Text: text,
+			Metadata: map[string]string{
+				"source":     source,
+				"created_at": now,
+			},
+		})
+		cancel()
+		if indexErr != nil {
+			log.Printf("memstore: mirror Index failed for memory #%d: %v", id, indexErr)
 		}
 	}
 


### PR DESCRIPTION
## Summary
Step 1.3 sub-part C1 — bring the unified \`memory.db\` up to date with real facts as the extractor/consolidator run, without moving any reader off memstore yet.

- Add \`mirror\` field + \`SetMirror(memory.Store)\` on \`memstore.Store\`.
- \`Store()\` now snapshots the mirror ref after the primary INSERT + embed, releases \`s.mu\`, then calls \`mirror.Index(scope=memType, doc_id=fmt.Sprint(id), source + created_at in metadata)\`. Mirror errors are logged and swallowed — primary write is authoritative.
- Daemon wires \`memDB.SetMirror(memStore)\` right after both stores are opened, so every extractor / consolidator / socket-server write now also lands in \`memory.db\`'s documents table under the memory type as Scope.

No reader migrated yet — sub-ticket C2 flips \`MemoryRecaller\` / \`handler_memory\` off \`*memstore.Store\` onto \`memory.Store.Search\` once there's enough dual-written data to be useful.

Part of #337.

## Test plan
- [x] Two new tests in \`internal/memstore/mirror_test.go\`: forwards-writes + scope isolation (preference vs fact).
- [x] \`make regression-quick\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)