### PR TITLE
refactor(daemon): one-shot memstore → memory.Store import (#337 part C3)

### DIFF
--- a/cmd/alf-daemon/main.go
+++ b/cmd/alf-daemon/main.go
@@ -489,9 +489,20 @@ func main() {
 	// Dual-write shim for #337c1: every memstore.Store write also lands in
 	// memory.Store as an Index(scope=type, id=fmt.Sprint(memID)). Lets the
 	// unified store fill up as the extractor runs, without moving any
-	// reader off memstore yet. The reader migration is sub-ticket C2.
+	// reader off memstore yet.
 	if memDB != nil {
 		memDB.SetMirror(memStore)
+	}
+
+	// One-shot backfill of pre-#337 memstore data into memory.Store so the
+	// recallers (#337c2, now reading from memory.Store) see the existing
+	// fact corpus. Sentinel-gated so it runs exactly once per install.
+	// Non-fatal — a failed migration logs and continues; memstore still
+	// serves the old data through the dual-write shim + next extractor run.
+	if cfg.EffectiveMemoryEnabled() {
+		if err := migrateMemstoreToMemory(context.Background(), contextDir, memStore); err != nil {
+			log.Printf("[memstore-migrate] failed: %v", err)
+		}
 	}
 
 	// Provider: spawn-per-call Claude CLI for responses.

--- a/cmd/alf-daemon/memstoremigrate.go
+++ b/cmd/alf-daemon/memstoremigrate.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/alamparelli/alf/internal/memory"
+)
+
+// DEPRECATED — scheduled removal target: v0.7.14 (same cycle as
+// migrateChatDBToMemoryDB — see memorymigrate.go).
+//
+// migrateMemstoreToMemory is the #337c3 one-shot importer. It copies the
+// contents of the legacy memstore database (contextDir/memory.db, table
+// `memories`) into the unified memory.Store's `documents` table so recall
+// — which now reads from memory.Store (#337c2) — sees every pre-existing
+// fact the user has built up.
+//
+// Idempotent: a sentinel file (contextDir/.memstore_migrated) records
+// completion so subsequent boots are a no-op. The legacy DB is NOT
+// renamed because memstore itself still opens it for the C1 dual-write
+// shim — both paths coexist until #337c4 retires memstore.
+//
+// Safety:
+//   - Each row is written via memory.Store.Index(scope=type,
+//     doc_id=fmt.Sprint(id)); the store's ON CONFLICT(scope, doc_id) DO
+//     UPDATE means a row already mirrored by C1 is refreshed, not
+//     duplicated.
+//   - Errors on individual rows are logged and skipped, not fatal —
+//     one malformed memory must not black-hole the migration of the
+//     other 99%.
+//   - The sentinel is written only after the full pass completes so a
+//     crashed migration re-runs cleanly on the next boot.
+func migrateMemstoreToMemory(ctx context.Context, contextDir string, memStore memory.Store) error {
+	legacyPath := filepath.Join(contextDir, "memory.db")
+	sentinel := filepath.Join(contextDir, ".memstore_migrated")
+
+	if _, err := os.Stat(sentinel); err == nil {
+		return nil
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		if os.IsNotExist(err) {
+			// Nothing to migrate. Write sentinel so we don't keep
+			// probing the filesystem on every boot.
+			return writeSentinel(sentinel)
+		}
+		return fmt.Errorf("stat legacy memstore.db: %w", err)
+	}
+
+	// Open read-only. WAL + busy_timeout match the pragmas memstore itself
+	// uses — means the live handle that memstore holds will not block us
+	// (readers never conflict under WAL).
+	legacyDB, err := sql.Open("sqlite3", legacyPath+"?mode=ro&_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		return fmt.Errorf("open legacy memstore.db: %w", err)
+	}
+	defer legacyDB.Close()
+
+	// If there's no `memories` table (e.g. the file is a fresh chat.db that
+	// got stray-named into contextDir), nothing to do.
+	var has int
+	if err := legacyDB.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='memories'`,
+	).Scan(&has); err != nil || has == 0 {
+		return writeSentinel(sentinel)
+	}
+
+	rows, err := legacyDB.QueryContext(ctx, `
+		SELECT id, text, type, source, metadata, created_at
+		FROM memories
+		ORDER BY id ASC`)
+	if err != nil {
+		return fmt.Errorf("read memories: %w", err)
+	}
+	defer rows.Close()
+
+	var imported, skipped int64
+	start := time.Now()
+	for rows.Next() {
+		var id int64
+		var text, memType, source, metaJSON, createdAt string
+		if err := rows.Scan(&id, &text, &memType, &source, &metaJSON, &createdAt); err != nil {
+			log.Printf("[memstore-migrate] scan row: %v", err)
+			skipped++
+			continue
+		}
+		meta := map[string]string{"source": source, "created_at": createdAt}
+		// Flatten the original JSON metadata into string values — memory
+		// Document metadata is map[string]string. Non-string values are
+		// re-encoded so nothing is silently dropped.
+		if metaJSON != "" && metaJSON != "{}" {
+			var raw map[string]any
+			if json.Unmarshal([]byte(metaJSON), &raw) == nil {
+				for k, v := range raw {
+					switch vv := v.(type) {
+					case string:
+						meta[k] = vv
+					default:
+						if b, err := json.Marshal(v); err == nil {
+							meta[k] = string(b)
+						}
+					}
+				}
+			}
+		}
+		if err := memStore.Index(ctx, memory.Scope(memType), memory.Document{
+			ID:       fmt.Sprintf("%d", id),
+			Text:     text,
+			Metadata: meta,
+		}); err != nil {
+			log.Printf("[memstore-migrate] Index memory #%d scope=%q: %v", id, memType, err)
+			skipped++
+			continue
+		}
+		imported++
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate memories: %w", err)
+	}
+
+	if err := writeSentinel(sentinel); err != nil {
+		log.Printf("[memstore-migrate] WARNING: import done but sentinel write failed: %v (next boot will re-run; Index is upsert-safe)", err)
+	}
+
+	log.Printf("[memstore-migrate] imported %d memories (skipped %d) from %s in %s",
+		imported, skipped, legacyPath, time.Since(start).Round(time.Millisecond))
+	return nil
+}
+
+// writeSentinel drops a zero-byte marker file to record migration completion.
+// The content doesn't matter — only the file's existence is consulted.
+func writeSentinel(path string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/cmd/alf-daemon/memstoremigrate_test.go
+++ b/cmd/alf-daemon/memstoremigrate_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alamparelli/alf/internal/memory"
+	"github.com/alamparelli/alf/internal/memstore"
+)
+
+// seedMemstore opens a memstore in contextDir and writes a handful of
+// typed memories. Returns the directory so the caller can point the
+// migration at it.
+func seedMemstore(t *testing.T, contextDir string) {
+	t.Helper()
+	store, err := memstore.New(filepath.Join(contextDir, "memory.db"), nil)
+	if err != nil {
+		t.Fatalf("memstore.New: %v", err)
+	}
+	defer store.Close()
+
+	seeds := []struct{ text, typ, source string }{
+		{"the deployment uses docker compose on homelab", "fact", "extractor"},
+		{"user prefers dark mode for all applications", "preference", "extractor"},
+		{"decided to use sqlite-vec for vector storage", "decision", "extractor"},
+		{"contact John Doe +1-555-0100", "contact", "extractor"},
+	}
+	for _, s := range seeds {
+		if _, err := store.Store(s.text, s.typ, s.source, nil); err != nil {
+			t.Fatalf("seed %q: %v", s.text, err)
+		}
+	}
+}
+
+// TestMigrateMemstoreToMemory_CopiesAllTypes verifies the migrator imports
+// every memstore memory into memory.Store under its memType as Scope, and
+// that scope-isolated Search returns each one afterwards.
+func TestMigrateMemstoreToMemory_CopiesAllTypes(t *testing.T) {
+	dataDir := t.TempDir()
+	contextDir := filepath.Join(dataDir, "context")
+	if err := os.MkdirAll(contextDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedMemstore(t, contextDir)
+
+	memStore, err := memory.NewSQLiteStore(dataDir)
+	if err != nil {
+		t.Fatalf("memory.NewSQLiteStore: %v", err)
+	}
+	defer memStore.Close()
+
+	ctx := context.Background()
+	if err := migrateMemstoreToMemory(ctx, contextDir, memStore); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Each seeded memory must be retrievable from its scope.
+	cases := []struct {
+		scope, query string
+	}{
+		{"fact", "docker compose"},
+		{"preference", "dark mode"},
+		{"decision", "sqlite-vec"},
+		{"contact", "John Doe"},
+	}
+	for _, tc := range cases {
+		hits, err := memStore.Search(ctx, memory.Scope(tc.scope), tc.query, 5)
+		if err != nil {
+			t.Errorf("Search scope=%q: %v", tc.scope, err)
+			continue
+		}
+		if len(hits) == 0 {
+			t.Errorf("Search scope=%q query=%q: no hits", tc.scope, tc.query)
+			continue
+		}
+		if hits[0].Document.Metadata["source"] != "extractor" {
+			t.Errorf("scope=%q: expected source='extractor', got %q", tc.scope, hits[0].Document.Metadata["source"])
+		}
+	}
+}
+
+// TestMigrateMemstoreToMemory_IsIdempotent confirms the sentinel gates
+// re-runs so repeated boots don't re-import and don't crash.
+func TestMigrateMemstoreToMemory_IsIdempotent(t *testing.T) {
+	dataDir := t.TempDir()
+	contextDir := filepath.Join(dataDir, "context")
+	if err := os.MkdirAll(contextDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedMemstore(t, contextDir)
+
+	memStore, err := memory.NewSQLiteStore(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer memStore.Close()
+
+	ctx := context.Background()
+	if err := migrateMemstoreToMemory(ctx, contextDir, memStore); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if err := migrateMemstoreToMemory(ctx, contextDir, memStore); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	// Sentinel must exist after the first run.
+	if _, err := os.Stat(filepath.Join(contextDir, ".memstore_migrated")); err != nil {
+		t.Errorf("sentinel missing: %v", err)
+	}
+}
+
+// TestMigrateMemstoreToMemory_NoLegacyDB verifies the migration is a
+// no-op on a fresh install that has never had memstore.
+func TestMigrateMemstoreToMemory_NoLegacyDB(t *testing.T) {
+	dataDir := t.TempDir()
+	contextDir := filepath.Join(dataDir, "context")
+	if err := os.MkdirAll(contextDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	memStore, err := memory.NewSQLiteStore(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer memStore.Close()
+
+	if err := migrateMemstoreToMemory(context.Background(), contextDir, memStore); err != nil {
+		t.Fatalf("no-op migration returned error: %v", err)
+	}
+	// Sentinel must still be dropped so subsequent boots skip.
+	if _, err := os.Stat(filepath.Join(contextDir, ".memstore_migrated")); err != nil {
+		t.Errorf("fresh-install sentinel missing: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Step 1.3 sub-part C3 — backfill pre-#337 memories into \`memory.Store\` so the unified-store recallers (C2) see the full user corpus, not just what C1's dual-write shim has captured since upgrade.

- New \`migrateMemstoreToMemory\` reads \`contextDir/memory.db.memories\` and \`Index()\`es each row into \`memory.Store\` under \`scope=type, doc_id=id\`. Original metadata flattened into strings (non-string fields re-serialised).
- Sentinel-gated: writes \`contextDir/.memstore_migrated\` on success. Fresh installs drop the sentinel too so repeated probes don't stat-storm.
- Legacy file is NOT renamed — memstore keeps writing to it for the C1 dual-write shim until C4 retires memstore.
- \`memory.Store.Index\` is upsert-safe, so a crash mid-migration re-runs cleanly (C1-mirrored rows refresh, don't duplicate).
- Wired in bootstrap after \`memDB.SetMirror\`, gated on \`EffectiveMemoryEnabled()\`, failures logged not fatal.

Part of #337. Remaining: C4 — retire memstore (writer migration + package deletion + remove aliases).

## Test plan
- [x] Three tests: copies every type into its scope, idempotent across runs, no-op on a fresh install.
- [x] \`make regression-quick\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)