### PR TITLE
refactor(daemon): /api/memory/ingest writer → memory.Store + tests (#337 part C4a)

### DIFF
--- a/cmd/alf-daemon/adapters.go
+++ b/cmd/alf-daemon/adapters.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -234,6 +237,50 @@ func (c *commsTierStore) Snapshot() comms.TiersSnapshot {
 		}
 	}
 	return snap
+}
+
+// memoryIngestAdapter implements cc.MemoryStorer on top of memory.Store so
+// the /api/memory/ingest writer path can land on the unified store
+// (#337c4a). Preserves the legacy Store() signature so handler_memory.go
+// and its tests need no change.
+//
+// Doc ID strategy: derive from a SHA-256 prefix of the text so repeated
+// ingests of identical content upsert-refresh a single row rather than
+// accumulate copies. This is coarser than memstore's FTS5 fuzzy dedup —
+// it only catches byte-identical duplicates — but it keeps the natural
+// "idempotent re-ingest" behaviour that users rely on.
+type memoryIngestAdapter struct {
+	store memory.Store
+}
+
+func (a *memoryIngestAdapter) Store(text, memType, source string, meta map[string]any) (int64, error) {
+	if a.store == nil {
+		return 0, fmt.Errorf("memory: ingest adapter has no backing store")
+	}
+	h := sha256.Sum256([]byte(text))
+	docID := fmt.Sprintf("ingest-%x", h[:12])
+	mm := map[string]string{
+		"source":     source,
+		"created_at": time.Now().Format(time.RFC3339),
+	}
+	for k, v := range meta {
+		switch vv := v.(type) {
+		case string:
+			mm[k] = vv
+		default:
+			if b, err := json.Marshal(v); err == nil {
+				mm[k] = string(b)
+			}
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := a.store.Index(ctx, memory.Scope(memType), memory.Document{
+		ID: docID, Text: text, Metadata: mm,
+	}); err != nil {
+		return 0, err
+	}
+	return 0, nil
 }
 
 // memoryCommsRecaller adapts memory.Store to the comms.MemoryRecaller

--- a/cmd/alf-daemon/main.go
+++ b/cmd/alf-daemon/main.go
@@ -761,17 +761,15 @@ func main() {
 		SummarizationKeepLast:  cfg.EffectiveSummarizationKeepLast(),
 	})
 	// Initialize all optional dependencies in one place (issue #91).
-	// Reader path: memory.Store.Search (via fan-out across scopes).
-	// Writer path for /api/memory/ingest: still on *memstore.Store so the
-	// dual-write shim (C1) mirrors UI-ingested facts into documents too.
-	// Writer migration to memory.Store.Index is sub-ticket C4.
+	// Reader path: memory.Store.Search via fan-out across scopes (#337c2).
+	// Writer path for /api/memory/ingest: memory.Store.Index via the ingest
+	// adapter (#337c4a). memstore's dual-write shim still fires for legacy
+	// write paths (extractor/consolidator/socket-server) until they retire.
 	var recaller cc.MemoryRecaller
 	var memRecallStore cc.MemoryStorer
 	if cfg.EffectiveMemoryEnabled() {
 		recaller = &memoryCCRecaller{store: memStore}
-	}
-	if memDB != nil {
-		memRecallStore = memDB
+		memRecallStore = &memoryIngestAdapter{store: memStore}
 	}
 	chatService.Init(cc.ChatServiceOpts{
 		Registry:       registry,

--- a/cmd/alf-daemon/memory_ingest_test.go
+++ b/cmd/alf-daemon/memory_ingest_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/alamparelli/alf/internal/memory"
+)
+
+// newTestMemoryStore returns an isolated memory.Store for adapter tests.
+// Uses an on-disk DB under t.TempDir() because the embedder-off path
+// still exercises SQLite behaviour that :memory: won't replicate
+// identically (e.g. WAL + busy_timeout pragmas).
+func newTestMemoryStore(t *testing.T) memory.Store {
+	t.Helper()
+	s, err := memory.NewSQLiteStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("memory.NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+// TestMemoryIngestAdapter_StoresUnderScope verifies that a Store() call
+// lands as an Index under scope=memType and that the text is retrievable
+// via Search on that same scope.
+func TestMemoryIngestAdapter_StoresUnderScope(t *testing.T) {
+	store := newTestMemoryStore(t)
+	a := &memoryIngestAdapter{store: store}
+
+	if _, err := a.Store("user likes dark themes", "preference", "user-import", nil); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	ctx := context.Background()
+	hits, err := store.Search(ctx, "preference", "dark themes", 5)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 hit, got %d", len(hits))
+	}
+	if !strings.Contains(hits[0].Document.Text, "dark themes") {
+		t.Errorf("round-trip lost text: %q", hits[0].Document.Text)
+	}
+	if hits[0].Document.Metadata["source"] != "user-import" {
+		t.Errorf("metadata.source = %q, want %q", hits[0].Document.Metadata["source"], "user-import")
+	}
+	if hits[0].Document.Metadata["created_at"] == "" {
+		t.Errorf("metadata.created_at should be populated")
+	}
+}
+
+// TestMemoryIngestAdapter_IdempotentOnIdenticalText catches the dedup
+// semantic: two Store() calls with identical text must produce the same
+// doc_id (sha256-derived), so the documents table holds exactly one row.
+func TestMemoryIngestAdapter_IdempotentOnIdenticalText(t *testing.T) {
+	store := newTestMemoryStore(t)
+	a := &memoryIngestAdapter{store: store}
+
+	text := "project runs on Go 1.24 with sqlite-vec"
+	if _, err := a.Store(text, "fact", "user-import", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.Store(text, "fact", "user-import", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	hits, _ := store.Search(ctx, "fact", "Go 1.24", 10)
+	if len(hits) != 1 {
+		t.Errorf("expected idempotent upsert (1 row), got %d hits with text=%q", len(hits), text)
+	}
+}
+
+// TestMemoryIngestAdapter_ScopeIsolation verifies that the same text
+// ingested under two different memTypes lands as two distinct documents
+// (different scopes), not one — scopes are independent namespaces.
+func TestMemoryIngestAdapter_ScopeIsolation(t *testing.T) {
+	store := newTestMemoryStore(t)
+	a := &memoryIngestAdapter{store: store}
+
+	text := "alpha beta gamma"
+	if _, err := a.Store(text, "fact", "user-import", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.Store(text, "preference", "user-import", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	fHits, _ := store.Search(ctx, "fact", "alpha", 5)
+	pHits, _ := store.Search(ctx, "preference", "alpha", 5)
+	if len(fHits) != 1 || len(pHits) != 1 {
+		t.Errorf("expected 1 hit in each scope, got fact=%d preference=%d", len(fHits), len(pHits))
+	}
+}
+
+// TestMemoryIngestAdapter_DocIDIsStable pins the doc_id derivation so the
+// idempotency story stays reproducible across releases — if the hash
+// strategy changes, existing installs would see duplicates on re-ingest.
+func TestMemoryIngestAdapter_DocIDIsStable(t *testing.T) {
+	text := "the cat sat on the mat"
+	h := sha256.Sum256([]byte(text))
+	want := fmt.Sprintf("ingest-%x", h[:12])
+
+	store := newTestMemoryStore(t)
+	a := &memoryIngestAdapter{store: store}
+	if _, err := a.Store(text, "fact", "user-import", nil); err != nil {
+		t.Fatal(err)
+	}
+	// Search by known scope and confirm doc_id matches the formula.
+	ctx := context.Background()
+	hits, _ := store.Search(ctx, "fact", "cat", 5)
+	if len(hits) == 0 {
+		t.Fatal("no hits")
+	}
+	if hits[0].Document.ID != want {
+		t.Errorf("doc_id changed: got %q, want %q", hits[0].Document.ID, want)
+	}
+}
+
+// TestMemoryIngestAdapter_NilMetaIsFine guards a regression mode where
+// the adapter mishandled a nil meta arg from handler_memory.go's
+// storeAsIs path. The built-in source/created_at keys must still land.
+func TestMemoryIngestAdapter_NilMetaIsFine(t *testing.T) {
+	store := newTestMemoryStore(t)
+	a := &memoryIngestAdapter{store: store}
+
+	if _, err := a.Store("nil meta passes", "fact", "user-import", nil); err != nil {
+		t.Fatalf("Store with nil meta: %v", err)
+	}
+	ctx := context.Background()
+	hits, _ := store.Search(ctx, "fact", "nil meta", 5)
+	if len(hits) == 0 {
+		t.Fatal("no hits")
+	}
+	if hits[0].Document.Metadata["source"] == "" {
+		t.Errorf("source metadata dropped with nil input meta")
+	}
+}
+
+// TestMemoryIngestAdapter_NonStringMetaIsJSONSerialised confirms the
+// adapter does not silently drop non-string meta values — they are
+// JSON-encoded so downstream consumers can recover them.
+func TestMemoryIngestAdapter_NonStringMetaIsJSONSerialised(t *testing.T) {
+	store := newTestMemoryStore(t)
+	a := &memoryIngestAdapter{store: store}
+
+	meta := map[string]any{
+		"stringy": "keepasis",
+		"numeric": 42,
+		"arr":     []string{"a", "b"},
+	}
+	if _, err := a.Store("serialise me", "fact", "user-import", meta); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	hits, _ := store.Search(ctx, "fact", "serialise", 5)
+	if len(hits) == 0 {
+		t.Fatal("no hits")
+	}
+	md := hits[0].Document.Metadata
+	if md["stringy"] != "keepasis" {
+		t.Errorf("string value lost: %q", md["stringy"])
+	}
+	// Numeric → JSON number string.
+	if md["numeric"] != "42" {
+		t.Errorf("numeric meta: got %q, want %q", md["numeric"], "42")
+	}
+	// Array → JSON array string.
+	var got []string
+	if err := json.Unmarshal([]byte(md["arr"]), &got); err != nil || len(got) != 2 {
+		t.Errorf("arr meta did not round-trip as JSON: raw=%q err=%v", md["arr"], err)
+	}
+}
+
+// TestMemoryIngestAdapter_ConcurrentStoresAreSafe exercises the adapter
+// under parallel writers — the memory.Store backend serializes writes
+// under a single connection, so this is really a race-detector smoke
+// test for the adapter wrapper itself and the SHA-256 / metadata
+// derivation path.
+func TestMemoryIngestAdapter_ConcurrentStoresAreSafe(t *testing.T) {
+	store := newTestMemoryStore(t)
+	a := &memoryIngestAdapter{store: store}
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			text := fmt.Sprintf("concurrent fact number %d about testing", i)
+			if _, err := a.Store(text, "fact", "user-import", nil); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent Store: %v", err)
+	}
+
+	// Every row must be independently retrievable.
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		q := fmt.Sprintf("number %d", i)
+		hits, err := store.Search(ctx, "fact", q, 5)
+		if err != nil {
+			t.Errorf("Search %q: %v", q, err)
+			continue
+		}
+		if len(hits) == 0 {
+			t.Errorf("row %d missing after concurrent Store", i)
+		}
+	}
+}
+
+// TestMemoryIngestAdapter_NilStoreReturnsError guards the bootstrap
+// mistake of wiring the adapter before the memory.Store is open — the
+// caller must get a clear error instead of a nil-pointer panic.
+func TestMemoryIngestAdapter_NilStoreReturnsError(t *testing.T) {
+	a := &memoryIngestAdapter{store: nil}
+	_, err := a.Store("anything", "fact", "user-import", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
Step 1.3 sub-part C4a — migrate the \`MemoryStorer\` writer path (\`/api/memory/ingest\`) off \`*memstore.Store\` onto \`memory.Store.Index\`. First cut of C4 — the socket server, extractor, and consolidator writers still run on memstore; those retire in follow-up sub-tickets.

- New \`memoryIngestAdapter\` implements \`cc.MemoryStorer\` on top of \`memory.Store\`.
- Doc ID = \`"ingest-" + sha256(text)[:12]\` so identical re-ingests upsert a single row. Coarser than memstore's FTS5 fuzzy dedup but matches the \"idempotent re-ingest\" UX users rely on.
- Non-string meta values are JSON-serialised (memory \`Metadata\` is \`map[string]string\`) so nothing is silently dropped.
- \`main.go\` wires the adapter as \`memRecallStore\` when memory is enabled.

## Test coverage
Eight new tests in \`memory_ingest_test.go\`:
- \`StoresUnderScope\` — scope = memType + metadata round-trip
- \`IdempotentOnIdenticalText\` — same text → one row, not two
- \`ScopeIsolation\` — same text under different memTypes → two rows
- \`DocIDIsStable\` — pins the sha256 prefix formula across releases
- \`NilMetaIsFine\` — guards the \`storeAsIs\` nil-meta path
- \`NonStringMetaIsJSONSerialised\` — numeric + array meta round-trip
- \`ConcurrentStoresAreSafe\` — 20× parallel \`Store\` calls, race-clean
- \`NilStoreReturnsError\` — bootstrap misconfiguration is loud, not a panic

## Test plan
- [x] \`make regression-quick\` green.
- [x] \`go test -race -tags fts5 ./cmd/alf-daemon ./internal/memory ./internal/memstore\` clean.

Part of #337. Remaining: C4b (socket server + memory-tools), C4c (extractor + consolidator writer migration), C4d (delete memstore + aliases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)