### PR TITLE
refactor(memory): GetDocument + DeleteDocument on Store (#337 part C4b1)

### DIFF
--- a/internal/memory/inmem.go
+++ b/internal/memory/inmem.go
@@ -536,6 +536,60 @@ func (s *InMem) Search(ctx context.Context, scope Scope, query string, k int) ([
 	return out, nil
 }
 
+func (s *InMem) GetDocument(ctx context.Context, scope Scope, docID string) (*Document, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		return nil, errors.New("memory: GetDocument: empty scope")
+	}
+	if docID == "" {
+		return nil, errors.New("memory: GetDocument: empty docID")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	docs, ok := s.documents[scope]
+	if !ok {
+		return nil, nil
+	}
+	d, ok := docs[docID]
+	if !ok {
+		return nil, nil
+	}
+	return &d, nil
+}
+
+func (s *InMem) DeleteDocument(ctx context.Context, scope Scope, docID string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if scope == "" {
+		return false, errors.New("memory: DeleteDocument: empty scope")
+	}
+	if docID == "" {
+		return false, errors.New("memory: DeleteDocument: empty docID")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	docs, ok := s.documents[scope]
+	if !ok {
+		return false, nil
+	}
+	if _, ok := docs[docID]; !ok {
+		return false, nil
+	}
+	delete(docs, docID)
+	// Preserve docOrder invariant: strip docID from the ordered slice.
+	order := s.docOrder[scope]
+	for i, id := range order {
+		if id == docID {
+			s.docOrder[scope] = append(order[:i], order[i+1:]...)
+			break
+		}
+	}
+	return true, nil
+}
+
 // Preferences ---------------------------------------------------------------
 
 func (s *InMem) GetPref(ctx context.Context, key string) (Value, error) {

--- a/internal/memory/memtest/contract.go
+++ b/internal/memory/memtest/contract.go
@@ -62,6 +62,14 @@ func RunStoreContract(t *testing.T, factory Factory) {
 	t.Run("Search_KZeroReturnsEmpty", func(t *testing.T) { testSearchKZero(t, factory) })
 	t.Run("Search_KNegativeErrors", func(t *testing.T) { testSearchKNegative(t, factory) })
 	t.Run("Index_RejectsEmptyID", func(t *testing.T) { testIndexEmptyID(t, factory) })
+	t.Run("GetDocument_Roundtrip", func(t *testing.T) { testGetDocumentRoundtrip(t, factory) })
+	t.Run("GetDocument_UnknownReturnsNil", func(t *testing.T) { testGetDocumentUnknown(t, factory) })
+	t.Run("GetDocument_ScopeIsolation", func(t *testing.T) { testGetDocumentScopeIsolation(t, factory) })
+	t.Run("GetDocument_RejectsEmpty", func(t *testing.T) { testGetDocumentRejectsEmpty(t, factory) })
+	t.Run("DeleteDocument_RemovesAndSearchExcludes", func(t *testing.T) { testDeleteDocumentRemoves(t, factory) })
+	t.Run("DeleteDocument_UnknownReturnsFalse", func(t *testing.T) { testDeleteDocumentUnknown(t, factory) })
+	t.Run("DeleteDocument_ScopeIsolation", func(t *testing.T) { testDeleteDocumentScopeIsolation(t, factory) })
+	t.Run("DeleteDocument_RejectsEmpty", func(t *testing.T) { testDeleteDocumentRejectsEmpty(t, factory) })
 	t.Run("Prefs_Roundtrip", func(t *testing.T) { testPrefsRoundtrip(t, factory) })
 	t.Run("Prefs_UnsetReturnsNil", func(t *testing.T) { testPrefsUnset(t, factory) })
 	t.Run("Prefs_NilValueClears", func(t *testing.T) { testPrefsNilClears(t, factory) })
@@ -340,6 +348,135 @@ func testIndexEmptyID(t *testing.T, factory Factory) {
 	err := s.Index(context.Background(), "s", memory.Document{ID: "", Text: "x"})
 	if err == nil {
 		t.Errorf("Index with empty doc.ID should error")
+	}
+}
+
+func testGetDocumentRoundtrip(t *testing.T, factory Factory) {
+	s := factory()
+	ctx := context.Background()
+	_ = s.Index(ctx, "s", memory.Document{
+		ID:       "doc-1",
+		Text:     "hello world",
+		Metadata: map[string]string{"k": "v"},
+	})
+	got, err := s.GetDocument(ctx, "s", "doc-1")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetDocument returned nil on existing doc")
+	}
+	if got.ID != "doc-1" || got.Text != "hello world" {
+		t.Errorf("document mismatch: %+v", got)
+	}
+	if got.Metadata["k"] != "v" {
+		t.Errorf("metadata lost on roundtrip: %+v", got.Metadata)
+	}
+}
+
+func testGetDocumentUnknown(t *testing.T, factory Factory) {
+	s := factory()
+	got, err := s.GetDocument(context.Background(), "s", "does-not-exist")
+	if err != nil {
+		t.Fatalf("GetDocument unknown: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for unknown doc, got %+v", got)
+	}
+}
+
+func testGetDocumentScopeIsolation(t *testing.T, factory Factory) {
+	s := factory()
+	ctx := context.Background()
+	_ = s.Index(ctx, "A", memory.Document{ID: "shared", Text: "in A"})
+
+	// Same docID under a different scope must be a miss, not a leak.
+	got, err := s.GetDocument(ctx, "B", "shared")
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if got != nil {
+		t.Errorf("scope B saw doc from scope A: %+v", got)
+	}
+}
+
+func testGetDocumentRejectsEmpty(t *testing.T, factory Factory) {
+	s := factory()
+	if _, err := s.GetDocument(context.Background(), "", "id"); err == nil {
+		t.Errorf("GetDocument with empty scope should error")
+	}
+	if _, err := s.GetDocument(context.Background(), "s", ""); err == nil {
+		t.Errorf("GetDocument with empty docID should error")
+	}
+}
+
+func testDeleteDocumentRemoves(t *testing.T, factory Factory) {
+	s := factory()
+	ctx := context.Background()
+	_ = s.Index(ctx, "s", memory.Document{ID: "gone", Text: "ephemeral fact"})
+	_ = s.Index(ctx, "s", memory.Document{ID: "stay", Text: "persistent fact"})
+
+	ok, err := s.DeleteDocument(ctx, "s", "gone")
+	if err != nil {
+		t.Fatalf("DeleteDocument: %v", err)
+	}
+	if !ok {
+		t.Errorf("DeleteDocument returned false on existing doc")
+	}
+
+	// GetDocument must now miss.
+	got, _ := s.GetDocument(ctx, "s", "gone")
+	if got != nil {
+		t.Errorf("GetDocument after delete returned %+v", got)
+	}
+	// Search must not surface the deleted doc — the FTS/vec triggers must
+	// have cleaned up too, not just the base row.
+	hits, _ := s.Search(ctx, "s", "ephemeral", 10)
+	for _, h := range hits {
+		if h.Document.ID == "gone" {
+			t.Errorf("Search still returns deleted doc: %+v", h)
+		}
+	}
+	// And the sibling doc must survive.
+	if g, _ := s.GetDocument(ctx, "s", "stay"); g == nil {
+		t.Errorf("Delete wiped an unrelated doc")
+	}
+}
+
+func testDeleteDocumentUnknown(t *testing.T, factory Factory) {
+	s := factory()
+	ok, err := s.DeleteDocument(context.Background(), "s", "never-existed")
+	if err != nil {
+		t.Fatalf("DeleteDocument unknown: %v", err)
+	}
+	if ok {
+		t.Errorf("DeleteDocument returned true on missing doc")
+	}
+}
+
+func testDeleteDocumentScopeIsolation(t *testing.T, factory Factory) {
+	s := factory()
+	ctx := context.Background()
+	_ = s.Index(ctx, "A", memory.Document{ID: "shared", Text: "in A"})
+	_ = s.Index(ctx, "B", memory.Document{ID: "shared", Text: "in B"})
+
+	ok, err := s.DeleteDocument(ctx, "A", "shared")
+	if err != nil || !ok {
+		t.Fatalf("Delete(A/shared) ok=%v err=%v", ok, err)
+	}
+	// The B-scoped doc with the same docID must survive.
+	if g, _ := s.GetDocument(ctx, "B", "shared"); g == nil {
+		t.Errorf("DeleteDocument leaked across scopes: B/shared is gone")
+	}
+}
+
+func testDeleteDocumentRejectsEmpty(t *testing.T, factory Factory) {
+	s := factory()
+	if _, err := s.DeleteDocument(context.Background(), "", "id"); err == nil {
+		t.Errorf("DeleteDocument with empty scope should error")
+	}
+	if _, err := s.DeleteDocument(context.Background(), "s", ""); err == nil {
+		t.Errorf("DeleteDocument with empty docID should error")
 	}
 }
 

--- a/internal/memory/sqlite.go
+++ b/internal/memory/sqlite.go
@@ -1235,6 +1235,80 @@ func (s *SQLiteStore) searchVec(ctx context.Context, scope Scope, query string, 
 	return out, nil
 }
 
+func (s *SQLiteStore) GetDocument(ctx context.Context, scope Scope, docID string) (*Document, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		return nil, errors.New("memory: GetDocument: empty scope")
+	}
+	if docID == "" {
+		return nil, errors.New("memory: GetDocument: empty docID")
+	}
+	var d Document
+	var meta string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT doc_id, text, metadata FROM documents WHERE scope = ? AND doc_id = ?`,
+		string(scope), docID).Scan(&d.ID, &d.Text, &meta)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if meta != "" && meta != "{}" {
+		_ = json.Unmarshal([]byte(meta), &d.Metadata)
+	}
+	return &d, nil
+}
+
+func (s *SQLiteStore) DeleteDocument(ctx context.Context, scope Scope, docID string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if scope == "" {
+		return false, errors.New("memory: DeleteDocument: empty scope")
+	}
+	if docID == "" {
+		return false, errors.New("memory: DeleteDocument: empty docID")
+	}
+
+	// Look up the rowid first — needed to clean the vec table because vec0
+	// is a virtual table that doesn't participate in regular FK cascades.
+	// documents_fts is handled by the AFTER DELETE trigger (see
+	// migrateVecSchema).
+	var rowID int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT rowid FROM documents WHERE scope = ? AND doc_id = ?`,
+		string(scope), docID).Scan(&rowID)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	// Drop the vec row before deleting from documents — if the delete
+	// trigger on documents fires while the vec row is still present and
+	// the process crashes between the two DELETEs, reopening the DB would
+	// leave an orphan vec embedding. Ordering the vec DELETE first means
+	// the worst case is a document with no embedding (benign — Search
+	// just won't rank it).
+	if s.embedDim > 0 {
+		if _, err := s.db.ExecContext(ctx, `DELETE FROM documents_vec WHERE rowid = ?`, rowID); err != nil {
+			return false, fmt.Errorf("memory: DeleteDocument: vec cleanup: %w", err)
+		}
+	}
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM documents WHERE scope = ? AND doc_id = ?`,
+		string(scope), docID)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
 // Preferences ---------------------------------------------------------------
 
 func (s *SQLiteStore) GetPref(ctx context.Context, key string) (Value, error) {

--- a/internal/memory/sqlitevec_test.go
+++ b/internal/memory/sqlitevec_test.go
@@ -123,6 +123,53 @@ func TestSQLiteStore_NoEmbedder_FallsBackToLike(t *testing.T) {
 	}
 }
 
+// TestSQLiteStore_DeleteDocument_RemovesVecRow catches the failure mode
+// where DeleteDocument cleans the base row and FTS trigger fires, but
+// documents_vec keeps an orphan embedding that still matches in Search.
+// Exercises the vec path specifically — the generic contract test only
+// hits the LIKE fallback because it runs without an embedder.
+func TestSQLiteStore_DeleteDocument_RemovesVecRow(t *testing.T) {
+	emb := memtest.NewStubEmbedder(32)
+	s, err := memory.NewSQLiteStore(t.TempDir(), memory.WithEmbedder(emb))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	if err := s.Index(ctx, "s", memory.Document{ID: "v1", Text: "apple orange banana"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Index(ctx, "s", memory.Document{ID: "v2", Text: "apple mango kiwi"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Precondition: vec search returns both.
+	pre, _ := s.Search(ctx, "s", "apple", 5)
+	if len(pre) != 2 {
+		t.Fatalf("precondition: expected 2 hits, got %d", len(pre))
+	}
+
+	ok, err := s.DeleteDocument(ctx, "s", "v1")
+	if err != nil || !ok {
+		t.Fatalf("DeleteDocument: ok=%v err=%v", ok, err)
+	}
+
+	// Search must now only surface v2 — no orphan vec hit for v1.
+	hits, err := s.Search(ctx, "s", "apple", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if h.Document.ID == "v1" {
+			t.Errorf("vec search returned deleted doc v1: score=%f", h.Score)
+		}
+	}
+	if len(hits) == 0 {
+		t.Error("expected v2 to remain, got 0 hits")
+	}
+}
+
 // TestSQLiteStore_VecDim_PersistsAcrossOpens catches the schema-drift
 // failure mode where a store is re-opened with an embedder of a different
 // dimension. The second open must fail fast rather than silently corrupting

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -314,6 +314,21 @@ type Store interface {
 	// k == 0 returns (nil, nil).
 	Search(ctx context.Context, scope Scope, query string, k int) ([]Hit, error)
 
+	// GetDocument returns the document at (scope, docID). Unknown (scope,
+	// docID) returns (nil, nil) — matches the not-found convention for
+	// GetMessage / GetConv. Empty scope or docID are contract violations
+	// and MUST return an error.
+	GetDocument(ctx context.Context, scope Scope, docID string) (*Document, error)
+
+	// DeleteDocument removes (scope, docID) from the index. Also drops any
+	// embedded vector and FTS row the implementation keeps in lockstep
+	// with the documents table. Unknown (scope, docID) is a no-op — returns
+	// (false, nil). Empty scope or docID are contract violations and MUST
+	// return an error.
+	//
+	// Used by the /forget capability once the socket server retires (#337).
+	DeleteDocument(ctx context.Context, scope Scope, docID string) (bool, error)
+
 	// Preferences — replaces memory/preferences.
 
 	// GetPref returns the value for key or (nil, nil) if unset.


### PR DESCRIPTION
## Summary
Step 1.3 sub-part C4b1 — prerequisite for retiring the memstore socket server. The forget capability needs a way to remove indexed documents; a UI \"remove this memory\" flow wants to read one back before delete. Both are missing from the current contract.

## Contract additions
- \`GetDocument(ctx, scope, docID) (*Document, error)\` — returns nil for unknown, errors on empty scope or docID. Matches the not-found convention of \`GetMessage\` / \`GetConv\`.
- \`DeleteDocument(ctx, scope, docID) (bool, error)\` — returns false for unknown (no-op), errors on empty args. Also cleans the vec row so Search doesn't surface an orphan embedding; the FTS row is removed by the existing \`documents_ad\` trigger.

## Implementation notes
- \`SQLiteStore\`: two-step delete (vec row, then documents row) — a crash between them leaves an embedding-less doc (benign) rather than an orphan vec hit.
- \`InMem\`: deleted docID is also stripped from \`docOrder\` so Search insertion-order stays stable.

## Test coverage (9 new tests)
- 8 contract subtests in \`memtest\`: roundtrip, unknown→nil for both methods, scope isolation on get/delete, empty-arg rejection. Run against both InMem and SQLite backends.
- 1 SQLite-vec-specific test (\`TestSQLiteStore_DeleteDocument_RemovesVecRow\`) exercising the vec cleanup path the LIKE-only contract can't reach.

## Test plan
- [x] \`make regression-quick\` green.
- [x] \`go test -race -tags fts5 ./internal/memory\` clean.

No caller wiring — C4b2 ports the socket server onto these methods. Contract bump is forward-compatible.

Part of #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)