### PR TITLE
refactor(memory): ListDocuments on Store (#337 part C4d.1)

### DIFF
--- a/internal/memory/inmem.go
+++ b/internal/memory/inmem.go
@@ -559,6 +559,35 @@ func (s *InMem) GetDocument(ctx context.Context, scope Scope, docID string) (*Do
 	return &d, nil
 }
 
+func (s *InMem) ListDocuments(ctx context.Context, scope Scope, limit int) ([]Document, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		return nil, errors.New("memory: ListDocuments: empty scope")
+	}
+	if limit <= 0 {
+		return nil, errors.New("memory: ListDocuments: limit must be > 0")
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	docs, ok := s.documents[scope]
+	if !ok {
+		return nil, nil
+	}
+	order := s.docOrder[scope]
+	var out []Document
+	for _, id := range order {
+		if d, ok := docs[id]; ok {
+			out = append(out, d)
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
 func (s *InMem) DeleteDocument(ctx context.Context, scope Scope, docID string) (bool, error) {
 	if err := ctx.Err(); err != nil {
 		return false, err

--- a/internal/memory/memtest/contract.go
+++ b/internal/memory/memtest/contract.go
@@ -70,6 +70,11 @@ func RunStoreContract(t *testing.T, factory Factory) {
 	t.Run("DeleteDocument_UnknownReturnsFalse", func(t *testing.T) { testDeleteDocumentUnknown(t, factory) })
 	t.Run("DeleteDocument_ScopeIsolation", func(t *testing.T) { testDeleteDocumentScopeIsolation(t, factory) })
 	t.Run("DeleteDocument_RejectsEmpty", func(t *testing.T) { testDeleteDocumentRejectsEmpty(t, factory) })
+	t.Run("ListDocuments_InsertionOrder", func(t *testing.T) { testListDocumentsInsertionOrder(t, factory) })
+	t.Run("ListDocuments_RespectsLimit", func(t *testing.T) { testListDocumentsLimit(t, factory) })
+	t.Run("ListDocuments_ScopeIsolation", func(t *testing.T) { testListDocumentsScopeIsolation(t, factory) })
+	t.Run("ListDocuments_UnknownScopeIsEmpty", func(t *testing.T) { testListDocumentsUnknownScope(t, factory) })
+	t.Run("ListDocuments_RejectsInvalid", func(t *testing.T) { testListDocumentsRejectsInvalid(t, factory) })
 	t.Run("Prefs_Roundtrip", func(t *testing.T) { testPrefsRoundtrip(t, factory) })
 	t.Run("Prefs_UnsetReturnsNil", func(t *testing.T) { testPrefsUnset(t, factory) })
 	t.Run("Prefs_NilValueClears", func(t *testing.T) { testPrefsNilClears(t, factory) })
@@ -477,6 +482,84 @@ func testDeleteDocumentRejectsEmpty(t *testing.T, factory Factory) {
 	}
 	if _, err := s.DeleteDocument(context.Background(), "s", ""); err == nil {
 		t.Errorf("DeleteDocument with empty docID should error")
+	}
+}
+
+func testListDocumentsInsertionOrder(t *testing.T, factory Factory) {
+	s := factory()
+	ctx := context.Background()
+	// Index in deliberate order — List must preserve it.
+	_ = s.Index(ctx, "s", memory.Document{ID: "a", Text: "first"})
+	_ = s.Index(ctx, "s", memory.Document{ID: "b", Text: "second"})
+	_ = s.Index(ctx, "s", memory.Document{ID: "c", Text: "third"})
+
+	docs, err := s.ListDocuments(ctx, "s", 10)
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) != 3 {
+		t.Fatalf("want 3 docs, got %d", len(docs))
+	}
+	wantOrder := []string{"a", "b", "c"}
+	for i, want := range wantOrder {
+		if docs[i].ID != want {
+			t.Errorf("docs[%d].ID = %q, want %q", i, docs[i].ID, want)
+		}
+	}
+}
+
+func testListDocumentsLimit(t *testing.T, factory Factory) {
+	s := factory()
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		_ = s.Index(ctx, "s", memory.Document{ID: string(rune('a' + i)), Text: "x"})
+	}
+	docs, err := s.ListDocuments(ctx, "s", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docs) != 2 {
+		t.Errorf("limit=2 returned %d docs", len(docs))
+	}
+}
+
+func testListDocumentsScopeIsolation(t *testing.T, factory Factory) {
+	s := factory()
+	ctx := context.Background()
+	_ = s.Index(ctx, "A", memory.Document{ID: "1", Text: "a-stuff"})
+	_ = s.Index(ctx, "B", memory.Document{ID: "2", Text: "b-stuff"})
+
+	docsA, _ := s.ListDocuments(ctx, "A", 10)
+	if len(docsA) != 1 || docsA[0].ID != "1" {
+		t.Errorf("scope A leaked: got %+v", docsA)
+	}
+	docsB, _ := s.ListDocuments(ctx, "B", 10)
+	if len(docsB) != 1 || docsB[0].ID != "2" {
+		t.Errorf("scope B leaked: got %+v", docsB)
+	}
+}
+
+func testListDocumentsUnknownScope(t *testing.T, factory Factory) {
+	s := factory()
+	docs, err := s.ListDocuments(context.Background(), "never-written", 10)
+	if err != nil {
+		t.Fatalf("unknown scope ListDocuments: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Errorf("expected empty result for unknown scope, got %d docs", len(docs))
+	}
+}
+
+func testListDocumentsRejectsInvalid(t *testing.T, factory Factory) {
+	s := factory()
+	if _, err := s.ListDocuments(context.Background(), "", 10); err == nil {
+		t.Errorf("ListDocuments with empty scope should error")
+	}
+	if _, err := s.ListDocuments(context.Background(), "s", 0); err == nil {
+		t.Errorf("ListDocuments with limit=0 should error")
+	}
+	if _, err := s.ListDocuments(context.Background(), "s", -1); err == nil {
+		t.Errorf("ListDocuments with negative limit should error")
 	}
 }
 

--- a/internal/memory/sqlite.go
+++ b/internal/memory/sqlite.go
@@ -1262,6 +1262,45 @@ func (s *SQLiteStore) GetDocument(ctx context.Context, scope Scope, docID string
 	return &d, nil
 }
 
+func (s *SQLiteStore) ListDocuments(ctx context.Context, scope Scope, limit int) ([]Document, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if scope == "" {
+		return nil, errors.New("memory: ListDocuments: empty scope")
+	}
+	if limit <= 0 {
+		return nil, errors.New("memory: ListDocuments: limit must be > 0")
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT doc_id, text, metadata FROM documents
+		 WHERE scope = ?
+		 ORDER BY inserted_at ASC, rowid ASC
+		 LIMIT ?`,
+		string(scope), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Document
+	for rows.Next() {
+		var d Document
+		var meta string
+		if err := rows.Scan(&d.ID, &d.Text, &meta); err != nil {
+			return nil, err
+		}
+		if meta != "" && meta != "{}" {
+			_ = json.Unmarshal([]byte(meta), &d.Metadata)
+		}
+		out = append(out, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (s *SQLiteStore) DeleteDocument(ctx context.Context, scope Scope, docID string) (bool, error) {
 	if err := ctx.Err(); err != nil {
 		return false, err

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -329,6 +329,17 @@ type Store interface {
 	// Used by the /forget capability once the socket server retires (#337).
 	DeleteDocument(ctx context.Context, scope Scope, docID string) (bool, error)
 
+	// ListDocuments returns up to `limit` documents in scope, ordered
+	// by insertion time ascending (oldest first). Unknown scope returns
+	// (nil, nil). Empty scope is a contract violation and MUST return
+	// an error. limit <= 0 is an error; to page through a large corpus
+	// callers should issue multiple calls with bounded limits.
+	//
+	// Used by the Consolidator (#337c4d) to walk the full corpus for
+	// LLM-driven merge/retype/delete decisions. Not a Search — this
+	// method returns insertion-ordered rows with no relevance scoring.
+	ListDocuments(ctx context.Context, scope Scope, limit int) ([]Document, error)
+
 	// Preferences — replaces memory/preferences.
 
 	// GetPref returns the value for key or (nil, nil) if unset.


### PR DESCRIPTION
## Summary
Step 1.3 sub-part C4d.1 — prerequisite for migrating the Consolidator. It walks the full corpus to feed an LLM merge/retype/delete prompt; \`memory.Store\` only exposed scored \`Search\` and per-id \`GetDocument\`. \`ListDocuments\` closes the gap.

## Contract
\`ListDocuments(ctx, scope, limit) ([]Document, error)\` — returns up to \`limit\` docs in insertion order. Unknown scope → \`(nil, nil)\`. Empty scope or \`limit <= 0\` → error.

## Implementations
- \`SQLiteStore\`: \`ORDER BY inserted_at ASC, rowid ASC\` (stable even when rows share a ms).
- \`InMem\`: walks \`docOrder\` slice kept in sync by \`DeleteDocument\`.

## Test coverage — 10 contract subtests (5 per backend)
Insertion order, respects limit, scope isolation, unknown-scope is empty, rejects invalid (empty scope / limit=0 / limit<0).

## Test plan
- [x] \`make regression-quick\` green.
- [x] \`go test -race -tags fts5 ./internal/memory/...\` clean.

Part of #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)