### PR TITLE
refactor(memstore): migrate Consolidator onto memory.Store (#337 part C4d.2)

### DIFF
--- a/cmd/alf-daemon/main.go
+++ b/cmd/alf-daemon/main.go
@@ -1199,6 +1199,10 @@ func main() {
 
 		// Consolidator: dedup + fallback extraction every 6h.
 		consolidator := memstore.NewConsolidator(memDB, memExtractor, extractAdapter, extractTimeout)
+		// #337c4d2: consolidator walks memory.Store via ListDocuments
+		// across the same known scopes the socket server and recallers
+		// use. Same threshold as the extractor for symmetry.
+		consolidator.SetMemoryBackend(memStore, socketsrv.KnownScopes, 0.85)
 		sched.RegisterSystem("mem-consolidate", "Memory Consolidation", "@every 360m", func() error {
 			return consolidator.RunOnce()
 		}, "Review the long-term memory store for redundancy and quality. Use recall to sample memories across all types (fact, decision, preference, contact). For each group of similar or overlapping memories: keep the most accurate and complete version, delete duplicates with forget, and if needed consolidate into a single updated memory with remember. Do not remove unique information. Focus on reducing noise without data loss.")

--- a/internal/memstore/consolidator.go
+++ b/internal/memstore/consolidator.go
@@ -6,7 +6,11 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
+
+	"github.com/alamparelli/alf/internal/memory"
+	"github.com/alamparelli/alf/internal/memory/dedup"
 )
 
 // Consolidator periodically deduplicates and reorganizes the memory store.
@@ -17,6 +21,28 @@ type Consolidator struct {
 	extractor *Extractor
 	provider  ExtractorProvider
 	timeout   time.Duration
+
+	// #337c4d2 memory.Store backend — when set, consolidation walks
+	// memory.Store.ListDocuments across memScopes and applies actions
+	// via dedup.IndexWithDedup + memory.Store.DeleteDocument. The
+	// legacy memstore.Store path stays active when memStore is nil.
+	mu               sync.Mutex
+	memStore         memory.Store
+	memScopes        []memory.Scope
+	nearDupThreshold float32
+}
+
+// SetMemoryBackend rewires consolidation onto memory.Store. scopes
+// enumerate the memory types the Consolidator will walk (typically the
+// KnownScopes constant in socketsrv). threshold controls near-dup
+// skipping when the Consolidator writes merged text — set to the same
+// value you pass to Extractor.SetMemoryBackend.
+func (c *Consolidator) SetMemoryBackend(store memory.Store, scopes []memory.Scope, threshold float32) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.memStore = store
+	c.memScopes = append(c.memScopes[:0], scopes...)
+	c.nearDupThreshold = threshold
 }
 
 // NewConsolidator creates a new consolidator.
@@ -32,18 +58,33 @@ func NewConsolidator(store *Store, extractor *Extractor, prov ExtractorProvider,
 	}
 }
 
-// consolidationAction represents a single action the LLM wants to perform.
+// consolidationAction represents a single action the LLM wants to
+// perform on the legacy memstore. IDs are int64 (memstore autoincrement).
 type consolidationAction struct {
-	Action    string `json:"action"`     // "merge", "delete", "retype"
-	IDs       []int64 `json:"ids"`       // memory IDs involved
-	MergedText string `json:"merged_text,omitempty"` // for merge: the unified text
-	NewType   string  `json:"new_type,omitempty"`    // for retype: the correct type
-	Reason    string  `json:"reason"`
+	Action     string  `json:"action"`                // "merge", "delete", "retype"
+	IDs        []int64 `json:"ids"`                   // memory IDs involved
+	MergedText string  `json:"merged_text,omitempty"` // for merge: the unified text
+	NewType    string  `json:"new_type,omitempty"`    // for retype: the correct type
+	Reason     string  `json:"reason"`
+}
+
+// memoryConsolidationAction is the #337c4d2 equivalent when the
+// consolidator is wired to memory.Store. IDs are strings (memory.Store
+// docIDs, typically "mem-<sha256>" from dedup.DocID) and every action
+// carries the source scope so the handler can call DeleteDocument /
+// Index against the right scope without a lookup pass.
+type memoryConsolidationAction struct {
+	Action     string   `json:"action"`                // "merge", "delete", "retype"
+	Scope      string   `json:"scope"`                 // "fact" | "preference" | "decision" | "contact"
+	IDs        []string `json:"ids"`                   // memory.Store doc IDs
+	MergedText string   `json:"merged_text,omitempty"` // for merge
+	NewScope   string   `json:"new_scope,omitempty"`   // for retype (use scope-aware field name)
+	Reason     string   `json:"reason"`
 }
 
 // RunOnce performs one consolidation cycle:
 // 1. If the extractor has pending changes, extract first.
-// 2. Then consolidate the memstore (dedup, merge, retype, prune).
+// 2. Then consolidate the memory store (dedup, merge, retype, prune).
 func (c *Consolidator) RunOnce() error {
 	// Step 1: fallback extraction for unprocessed changes.
 	if c.extractor.HasChanges() {
@@ -54,7 +95,17 @@ func (c *Consolidator) RunOnce() error {
 		}
 	}
 
-	// Step 2: consolidate.
+	// Step 2: consolidate. Pick the backend snapshot once per run so a
+	// concurrent SetMemoryBackend call doesn't flip mid-cycle.
+	c.mu.Lock()
+	memStore := c.memStore
+	memScopes := append([]memory.Scope(nil), c.memScopes...)
+	threshold := c.nearDupThreshold
+	c.mu.Unlock()
+
+	if memStore != nil && len(memScopes) > 0 {
+		return c.consolidateMemory(memStore, memScopes, threshold)
+	}
 	return c.consolidate()
 }
 
@@ -142,6 +193,194 @@ func (c *Consolidator) consolidate() error {
 	log.Printf("memstore/consolidator: applied %d/%d actions", applied, len(actions))
 	return nil
 }
+
+// consolidateMemory is the #337c4d2 memory.Store-backed path. Walks
+// every configured scope via ListDocuments, asks the LLM for merge /
+// delete / retype actions in a single prompt, and applies them via
+// dedup.IndexWithDedup + DeleteDocument.
+func (c *Consolidator) consolidateMemory(store memory.Store, scopes []memory.Scope, threshold float32) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	// Walk every scope and build a (doc, scope) index table. The LLM
+	// sees string IDs scoped by their source — no per-action lookup is
+	// needed later because every action carries its scope.
+	type scoped struct {
+		doc   memory.Document
+		scope memory.Scope
+	}
+	var all []scoped
+	for _, sc := range scopes {
+		docs, err := store.ListDocuments(ctx, sc, 500)
+		if err != nil {
+			log.Printf("memstore/consolidator: list scope=%q: %v", sc, err)
+			continue
+		}
+		for _, d := range docs {
+			all = append(all, scoped{doc: d, scope: sc})
+		}
+	}
+	if len(all) < 5 {
+		log.Printf("memstore/consolidator: only %d memories across %d scopes, skipping", len(all), len(scopes))
+		return nil
+	}
+
+	var sb strings.Builder
+	for _, it := range all {
+		createdAt := it.doc.Metadata["created_at"]
+		if createdAt == "" {
+			createdAt = "unknown"
+		}
+		sb.WriteString(fmt.Sprintf("[ID:%s] [%s] [%s] %s\n", it.doc.ID, it.scope, createdAt, it.doc.Text))
+	}
+	log.Printf("memstore/consolidator: consolidating %d memories across %d scopes (%d bytes)", len(all), len(scopes), sb.Len())
+
+	actions, err := c.identifyMemoryActions(sb.String())
+	if err != nil {
+		return fmt.Errorf("identify memory actions: %w", err)
+	}
+	if len(actions) == 0 {
+		log.Printf("memstore/consolidator: no consolidation needed")
+		return nil
+	}
+
+	applied := 0
+	for _, a := range actions {
+		switch a.Action {
+		case "merge":
+			if len(a.IDs) < 2 || strings.TrimSpace(a.MergedText) == "" || a.Scope == "" {
+				continue
+			}
+			destScope := a.Scope
+			if a.NewScope != "" {
+				destScope = a.NewScope
+			}
+			// Write the merged fact first — if that fails we keep the
+			// originals untouched.
+			res, err := dedup.IndexWithDedup(ctx, store, memory.Scope(destScope), memory.Document{Text: a.MergedText}, dedup.Options{
+				Source:           "consolidator",
+				NearDupThreshold: threshold,
+				Now:              func() string { return time.Now().Format(time.RFC3339) },
+			})
+			if err != nil {
+				log.Printf("memstore/consolidator: merge write failed: %v", err)
+				continue
+			}
+			for _, id := range a.IDs {
+				if _, delErr := store.DeleteDocument(ctx, memory.Scope(a.Scope), id); delErr != nil {
+					log.Printf("memstore/consolidator: merge delete %s/%s failed: %v", a.Scope, id, delErr)
+				}
+			}
+			log.Printf("memstore/consolidator: merged %v → %s (scope=%s, stored=%v)", a.IDs, res.DocID, destScope, res.Stored)
+			applied++
+
+		case "delete":
+			if a.Scope == "" {
+				continue
+			}
+			for _, id := range a.IDs {
+				if _, err := store.DeleteDocument(ctx, memory.Scope(a.Scope), id); err != nil {
+					log.Printf("memstore/consolidator: delete %s/%s failed: %v", a.Scope, id, err)
+				}
+			}
+			applied++
+
+		case "retype":
+			if len(a.IDs) == 0 || a.NewScope == "" || a.Scope == "" {
+				continue
+			}
+			for _, id := range a.IDs {
+				existing, err := store.GetDocument(ctx, memory.Scope(a.Scope), id)
+				if err != nil || existing == nil {
+					continue
+				}
+				if _, err := store.DeleteDocument(ctx, memory.Scope(a.Scope), id); err != nil {
+					log.Printf("memstore/consolidator: retype delete %s/%s failed: %v", a.Scope, id, err)
+					continue
+				}
+				if _, err := dedup.IndexWithDedup(ctx, store, memory.Scope(a.NewScope), memory.Document{Text: existing.Text}, dedup.Options{
+					Source:           "consolidator",
+					NearDupThreshold: threshold,
+					Now:              func() string { return time.Now().Format(time.RFC3339) },
+				}); err != nil {
+					log.Printf("memstore/consolidator: retype write %s/%s → %s failed: %v", a.Scope, id, a.NewScope, err)
+				}
+			}
+			applied++
+		}
+	}
+
+	log.Printf("memstore/consolidator: applied %d/%d actions", applied, len(actions))
+	return nil
+}
+
+// identifyMemoryActions is the memory.Store-backed twin of
+// identifyActions. The prompt asks for scoped actions with string IDs
+// so the LLM response maps straight onto memory.Store operations
+// without a second lookup pass.
+func (c *Consolidator) identifyMemoryActions(memoryList string) ([]memoryConsolidationAction, error) {
+	prompt := fmt.Sprintf(memoryConsolidationPrompt, memoryList)
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	var model string
+	if c.extractor.tierResolver != nil {
+		model = c.extractor.tierResolver()
+	}
+	if model == "" {
+		return nil, fmt.Errorf("no tier available for memory consolidation (tierResolver returned empty)")
+	}
+
+	raw, err := c.provider.Invoke(ctx, prompt, ExtractorParams{
+		Model:    model,
+		MaxTurns: 1,
+		DataDir:  c.extractor.dataDir,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("LLM consolidation: %w", err)
+	}
+
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimPrefix(raw, "```json")
+	raw = strings.TrimPrefix(raw, "```")
+	raw = strings.TrimSuffix(raw, "```")
+	raw = strings.TrimSpace(raw)
+
+	var actions []memoryConsolidationAction
+	if err := json.Unmarshal([]byte(raw), &actions); err != nil {
+		if start := strings.Index(raw, "["); start != -1 {
+			if end := strings.LastIndex(raw, "]"); end > start {
+				if err2 := json.Unmarshal([]byte(raw[start:end+1]), &actions); err2 == nil {
+					return actions, nil
+				}
+			}
+		}
+		return nil, fmt.Errorf("parse consolidation response: %w (raw: %s)", err, truncateText(raw, 200))
+	}
+	return actions, nil
+}
+
+const memoryConsolidationPrompt = `You are a memory consolidation tool. Review the memory store and identify cleanup actions.
+
+Rules:
+- MERGE memories that say the same thing differently (keep the most complete version). Requires: scope, ids (>=2), merged_text, new_scope (usually same as scope).
+- DELETE memories that are clearly outdated, contradicted by newer entries, or trivially obvious. Requires: scope, ids.
+- RETYPE memories whose scope is wrong (e.g., a "fact" that is actually a "preference" or "decision"). Requires: scope (current), ids, new_scope (correct).
+- Do NOT delete memories that are still relevant even if old.
+- Do NOT merge memories that are about different topics even if related.
+- Be conservative — when in doubt, keep the memory.
+
+Valid scopes: "fact", "preference", "decision", "contact"
+
+Respond with ONLY a JSON array of actions:
+[{"action": "merge|delete|retype", "scope": "fact", "ids": ["mem-abc", "mem-def"], "merged_text": "... (merge only)", "new_scope": "... (merge/retype only)", "reason": "brief explanation"}]
+
+If no actions needed, respond with: []
+
+<memory_store>
+%s
+</memory_store>`
 
 const consolidationPrompt = `You are a memory consolidation tool. Review the memory store and identify cleanup actions.
 

--- a/internal/memstore/consolidator_memory_test.go
+++ b/internal/memstore/consolidator_memory_test.go
@@ -1,0 +1,297 @@
+package memstore_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/alamparelli/alf/internal/memory"
+	"github.com/alamparelli/alf/internal/memory/dedup"
+	"github.com/alamparelli/alf/internal/memstore"
+)
+
+// seedMemory writes n documents into memStore under scope, returning
+// their docIDs in insertion order so assertions can target them.
+func seedMemory(t *testing.T, store memory.Store, scope memory.Scope, texts ...string) []string {
+	t.Helper()
+	ctx := context.Background()
+	ids := make([]string, 0, len(texts))
+	for _, text := range texts {
+		r, err := dedup.IndexWithDedup(ctx, store, scope, memory.Document{Text: text}, dedup.Options{
+			Source: "test",
+			Now:    func() string { return "2026-01-01T00:00:00Z" },
+		})
+		if err != nil {
+			t.Fatalf("seed %q: %v", text, err)
+		}
+		ids = append(ids, r.DocID)
+	}
+	return ids
+}
+
+// consolidatorProvider canned-response provider for the Consolidator LLM
+// call. ExtractorProvider signature matches both extractor and
+// consolidator usage.
+type consolidatorProvider struct {
+	resp string
+	err  error
+}
+
+func (p *consolidatorProvider) Invoke(_ context.Context, _ string, _ memstore.ExtractorParams) (string, error) {
+	if p.err != nil {
+		return "", p.err
+	}
+	return p.resp, nil
+}
+
+// newConsolidatorWithMemory builds a Consolidator + Extractor pair
+// wired to a memory.Store. Mirrors the production bootstrap just
+// enough to drive RunOnce() end-to-end.
+func newConsolidatorWithMemory(t *testing.T, prov memstore.ExtractorProvider) (*memstore.Consolidator, memory.Store) {
+	t.Helper()
+	dataDir := t.TempDir()
+	initGitRepo(t, dataDir)
+
+	ms, err := memstore.New(filepath.Join(t.TempDir(), "ms.db"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ms.Close() })
+
+	memStore, err := memory.NewSQLiteStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = memStore.Close() })
+
+	ex := memstore.NewExtractor(ms, dataDir, t.TempDir(), memstore.ExtractorConfig{}, prov, func() string { return "test-model" })
+	ex.SetMemoryBackend(memStore, 0)
+	c := memstore.NewConsolidator(ms, ex, prov, 0)
+	c.SetMemoryBackend(memStore, []memory.Scope{"fact", "preference", "decision", "contact"}, 0)
+	return c, memStore
+}
+
+func jsonActions(v ...map[string]any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+// TestConsolidator_Memory_SkipsWhenFewMemories catches the early-exit
+// path — fewer than 5 rows across all scopes should not invoke the LLM
+// at all. Protects against accidental over-consolidation of tiny
+// corpora (first-boot users).
+func TestConsolidator_Memory_SkipsWhenFewMemories(t *testing.T) {
+	prov := &consolidatorProvider{resp: "[]"}
+	c, memStore := newConsolidatorWithMemory(t, prov)
+	_ = seedMemory(t, memStore, "fact", "only one fact")
+
+	if err := c.RunOnce(); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	// 1 row remains, LLM was not usefully consulted — verify the doc
+	// survived.
+	ctx := context.Background()
+	docs, _ := memStore.ListDocuments(ctx, "fact", 10)
+	if len(docs) != 1 {
+		t.Errorf("expected the sole fact to survive, got %d rows", len(docs))
+	}
+}
+
+// TestConsolidator_Memory_DeleteActionRemovesFromMemoryStore verifies
+// that a delete action issued by the LLM lands in memory.Store.
+// Also proves the scope field in the action routes the DeleteDocument
+// call correctly.
+func TestConsolidator_Memory_DeleteActionRemovesFromMemoryStore(t *testing.T) {
+	prov := &consolidatorProvider{} // resp set after seeding
+	c, memStore := newConsolidatorWithMemory(t, prov)
+
+	ids := seedMemory(t, memStore, "fact",
+		"fact one", "fact two", "fact three", "fact four", "fact five",
+	)
+	// Build an action the mock returns: delete the first two facts.
+	prov.resp = jsonActions(map[string]any{
+		"action": "delete",
+		"scope":  "fact",
+		"ids":    []string{ids[0], ids[1]},
+		"reason": "outdated in test",
+	})
+
+	if err := c.RunOnce(); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	ctx := context.Background()
+	if got, _ := memStore.GetDocument(ctx, "fact", ids[0]); got != nil {
+		t.Errorf("fact #0 should be deleted, still present")
+	}
+	if got, _ := memStore.GetDocument(ctx, "fact", ids[1]); got != nil {
+		t.Errorf("fact #1 should be deleted, still present")
+	}
+	if got, _ := memStore.GetDocument(ctx, "fact", ids[2]); got == nil {
+		t.Errorf("fact #2 should survive, got nil")
+	}
+}
+
+// TestConsolidator_Memory_MergeActionReplacesSourcesWithMerged verifies
+// the merge action: N source IDs are deleted and a single merged row
+// lands under the destination scope (new_scope or the source scope).
+func TestConsolidator_Memory_MergeActionReplacesSourcesWithMerged(t *testing.T) {
+	prov := &consolidatorProvider{}
+	c, memStore := newConsolidatorWithMemory(t, prov)
+
+	ids := seedMemory(t, memStore, "fact",
+		"the project runs on Go",
+		"Go 1.24 is the version",
+		"uses sqlite-vec for embeddings",
+		"deployed via docker compose",
+		"has a CI pipeline",
+	)
+	mergedText := "project runs Go 1.24 with sqlite-vec, deployed via docker compose"
+	prov.resp = jsonActions(map[string]any{
+		"action":      "merge",
+		"scope":       "fact",
+		"ids":         []string{ids[0], ids[1], ids[2], ids[3]},
+		"merged_text": mergedText,
+		"new_scope":   "fact",
+		"reason":      "consolidate redundant tech facts",
+	})
+
+	if err := c.RunOnce(); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	ctx := context.Background()
+	for i := 0; i < 4; i++ {
+		if got, _ := memStore.GetDocument(ctx, "fact", ids[i]); got != nil {
+			t.Errorf("source fact[%d] should be deleted after merge, still present", i)
+		}
+	}
+	// The merged row lands under the predictable dedup.DocID.
+	mergedID := dedup.DocID(mergedText)
+	got, _ := memStore.GetDocument(ctx, "fact", mergedID)
+	if got == nil {
+		t.Fatalf("merged row missing; expected docID=%s", mergedID)
+	}
+	if got.Text != mergedText {
+		t.Errorf("merged text = %q, want %q", got.Text, mergedText)
+	}
+	if got.Metadata["source"] != "consolidator" {
+		t.Errorf("source = %q, want consolidator", got.Metadata["source"])
+	}
+}
+
+// TestConsolidator_Memory_RetypeMovesBetweenScopes verifies that a
+// retype action deletes the document from the current scope and
+// re-indexes it under new_scope, preserving the text.
+func TestConsolidator_Memory_RetypeMovesBetweenScopes(t *testing.T) {
+	prov := &consolidatorProvider{}
+	c, memStore := newConsolidatorWithMemory(t, prov)
+
+	// Seed 4 facts — need >= 5 total for consolidate to engage.
+	_ = seedMemory(t, memStore, "fact",
+		"first fact", "second fact", "third fact", "fourth fact",
+	)
+	// Seed a fact that actually expresses a preference.
+	prefText := "user prefers dark themes everywhere"
+	prefIDs := seedMemory(t, memStore, "fact", prefText)
+
+	prov.resp = jsonActions(map[string]any{
+		"action":    "retype",
+		"scope":     "fact",
+		"ids":       []string{prefIDs[0]},
+		"new_scope": "preference",
+		"reason":    "this is a preference not a fact",
+	})
+
+	if err := c.RunOnce(); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	ctx := context.Background()
+	// Original scope is now empty for this doc.
+	if got, _ := memStore.GetDocument(ctx, "fact", prefIDs[0]); got != nil {
+		t.Errorf("retype should remove from source scope, still present")
+	}
+	// The text reappears under preference scope with a fresh hash-derived ID.
+	newID := dedup.DocID(prefText)
+	got, _ := memStore.GetDocument(ctx, "preference", newID)
+	if got == nil {
+		t.Fatalf("retype target missing under preference scope (docID=%s)", newID)
+	}
+	if got.Text != prefText {
+		t.Errorf("retype corrupted text: got %q", got.Text)
+	}
+}
+
+// TestConsolidator_Memory_EmptyActionsIsNoOp verifies that an LLM
+// response of [] leaves the store untouched — the "no consolidation
+// needed" branch.
+func TestConsolidator_Memory_EmptyActionsIsNoOp(t *testing.T) {
+	prov := &consolidatorProvider{resp: "[]"}
+	c, memStore := newConsolidatorWithMemory(t, prov)
+	ids := seedMemory(t, memStore, "fact", "a", "b", "c", "d", "e", "f")
+
+	if err := c.RunOnce(); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	ctx := context.Background()
+	for _, id := range ids {
+		if got, _ := memStore.GetDocument(ctx, "fact", id); got == nil {
+			t.Errorf("no-op consolidation lost doc %s", id)
+		}
+	}
+}
+
+// TestConsolidator_Memory_MalformedActionsAreRejected checks the LLM
+// response parsing layer: garbage back from the model must surface as
+// an error from RunOnce rather than silently skipping consolidation.
+func TestConsolidator_Memory_MalformedActionsAreRejected(t *testing.T) {
+	prov := &consolidatorProvider{resp: "{not json at all"}
+	c, memStore := newConsolidatorWithMemory(t, prov)
+	_ = seedMemory(t, memStore, "fact", "a", "b", "c", "d", "e", "f")
+
+	err := c.RunOnce()
+	if err == nil {
+		t.Fatalf("expected parse error for malformed LLM output, got nil")
+	}
+}
+
+// TestConsolidator_Memory_InvalidActionShapeSkipped catches the
+// defensive per-action validation: a merge missing merged_text or IDs
+// must be skipped without crashing the run.
+func TestConsolidator_Memory_InvalidActionShapeSkipped(t *testing.T) {
+	prov := &consolidatorProvider{}
+	c, memStore := newConsolidatorWithMemory(t, prov)
+	ids := seedMemory(t, memStore, "fact", "a", "b", "c", "d", "e", "f")
+
+	// Invalid merge: only one ID.
+	prov.resp = jsonActions(map[string]any{
+		"action":      "merge",
+		"scope":       "fact",
+		"ids":         []string{ids[0]},
+		"merged_text": "would-be merged",
+		"new_scope":   "fact",
+	})
+
+	if err := c.RunOnce(); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	// Original doc survived — merge was a no-op.
+	ctx := context.Background()
+	if got, _ := memStore.GetDocument(ctx, "fact", ids[0]); got == nil {
+		t.Errorf("invalid merge should have skipped; doc was deleted anyway")
+	}
+}
+
+// Ensure fmt and os are used (sibling test files pull them in; keep
+// imports stable if this file evolves).
+var (
+	_ = fmt.Sprintf
+	_ = os.Getenv
+	_ = exec.Command
+)


### PR DESCRIPTION
## Summary
Step 1.3 sub-part C4d.2 — the last memstore.Store writer moves to memory.Store. With this PR, the Extractor and Consolidator both use \`memory.Store.Index\` via \`dedup.IndexWithDedup\` and \`memory.Store.DeleteDocument\` for cleanup; \`memstore.Store.Store\` / \`Delete\` are no longer called from any production path. Final retirement of the memstore package is safe to land in C4d.3.

## Changes

**\`internal/memstore/consolidator.go\`**
- \`Consolidator.memStore / memScopes / nearDupThreshold\` fields + \`SetMemoryBackend\` setter.
- \`RunOnce\` picks the memory backend when wired, falls through to legacy path otherwise.
- \`consolidateMemory\` walks \`ListDocuments\` across every scope, asks the LLM for scoped actions, dispatches:
  - **merge** — \`IndexWithDedup(new_scope)\` + \`DeleteDocument(scope)\` for every source ID.
  - **delete** — \`DeleteDocument(scope)\` for every ID.
  - **retype** — \`GetDocument\` → \`DeleteDocument\` → \`IndexWithDedup(new_scope)\`.
- New \`memoryConsolidationAction\` type with string IDs + scope tags.
- New \`memoryConsolidationPrompt\`: scope-aware, string-id variant.

**\`cmd/alf-daemon/main.go\`**
- \`consolidator.SetMemoryBackend(memStore, socketsrv.KnownScopes, 0.85)\` — threshold matches extractor; scopes come from \`socketsrv.KnownScopes\` so recaller / socket / consolidator stay in sync through a single source of truth.

## Test coverage — 7 new tests
Skips-when-few-memories, delete action, merge action, retype action, empty-actions no-op, malformed-actions rejected, invalid-action-shape skipped.

## Test plan
- [x] \`make regression-quick\` green.
- [x] \`go test -race -tags fts5 ./internal/memory/... ./internal/memstore ./cmd/alf-daemon\` clean.

Part of #337. Remaining: C4d.3 — delete \`memstore\` package (legacy \`Store\`/\`Delete\` dead, aliases, dedup config plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)