### PR TITLE
refactor(capability): unified Registry + native tool adapter (#338)

### DIFF
--- a/internal/capability/registry.go
+++ b/internal/capability/registry.go
@@ -1,0 +1,93 @@
+package capability
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Registry is the unified catalog of every Capability ALF can execute —
+// native tools, skills, and installed apps.
+//
+// This registry is the target surface the Runtime (Step 4) will consume.
+// During Step 2 it lives alongside the legacy registries (tooling.Registry,
+// skills.Catalog, marketplace.Manager) via dual-registration; those legacy
+// registries are removed once all consumers have migrated.
+type Registry struct {
+	mu   sync.RWMutex
+	caps map[ID]Capability
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{caps: make(map[ID]Capability)}
+}
+
+// Register adds a Capability to the registry. Returns an error if the
+// Manifest ID is empty or already registered.
+func (r *Registry) Register(c Capability) error {
+	if c == nil {
+		return fmt.Errorf("capability: cannot register nil")
+	}
+	m := c.Manifest()
+	if m.ID == "" {
+		return fmt.Errorf("capability: manifest ID is empty")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.caps[m.ID]; exists {
+		return fmt.Errorf("capability: ID %q already registered", m.ID)
+	}
+	r.caps[m.ID] = c
+	return nil
+}
+
+// Get returns the Capability registered under id, or (nil, false) if absent.
+func (r *Registry) Get(id ID) (Capability, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c, ok := r.caps[id]
+	return c, ok
+}
+
+// Len returns the number of registered capabilities.
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.caps)
+}
+
+// All returns every registered Capability, sorted by ID for determinism.
+func (r *Registry) All() []Capability {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Capability, 0, len(r.caps))
+	ids := make([]ID, 0, len(r.caps))
+	for id := range r.caps {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		out = append(out, r.caps[id])
+	}
+	return out
+}
+
+// ByKind returns every registered Capability of the given Kind,
+// sorted by ID for determinism.
+func (r *Registry) ByKind(k Kind) []Capability {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]ID, 0, len(r.caps))
+	for id, c := range r.caps {
+		if c.Manifest().Kind == k {
+			ids = append(ids, id)
+		}
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	out := make([]Capability, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, r.caps[id])
+	}
+	return out
+}

--- a/internal/capability/registry_test.go
+++ b/internal/capability/registry_test.go
@@ -1,0 +1,178 @@
+package capability
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// stubCap is a minimal Capability used only in registry tests.
+type stubCap struct {
+	manifest Manifest
+}
+
+func (s stubCap) Manifest() Manifest         { return s.manifest }
+func (s stubCap) Permissions() PermissionSet { return s.manifest.Permissions }
+func (s stubCap) Execute(_ context.Context, _ Input) (Output, error) {
+	return Output{Data: "ok"}, nil
+}
+
+func newStub(id ID, k Kind) stubCap {
+	return stubCap{manifest: Manifest{ID: id, Kind: k, Name: string(id)}}
+}
+
+func TestRegistry_RegisterAndGet(t *testing.T) {
+	r := NewRegistry()
+	c := newStub("bash", KindTool)
+	if err := r.Register(c); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	got, ok := r.Get("bash")
+	if !ok {
+		t.Fatal("Get: expected capability, got nothing")
+	}
+	if got.Manifest().ID != "bash" {
+		t.Fatalf("Get: want id=bash, got %q", got.Manifest().ID)
+	}
+	if r.Len() != 1 {
+		t.Fatalf("Len: want 1, got %d", r.Len())
+	}
+}
+
+func TestRegistry_RegisterNilRejected(t *testing.T) {
+	r := NewRegistry()
+	err := r.Register(nil)
+	if err == nil {
+		t.Fatal("Register(nil): expected error, got nil")
+	}
+}
+
+func TestRegistry_RegisterEmptyIDRejected(t *testing.T) {
+	r := NewRegistry()
+	c := stubCap{manifest: Manifest{ID: "", Kind: KindTool}}
+	err := r.Register(c)
+	if err == nil {
+		t.Fatal("Register(empty ID): expected error, got nil")
+	}
+}
+
+func TestRegistry_RegisterDuplicateRejected(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register(newStub("bash", KindTool)); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	err := r.Register(newStub("bash", KindTool))
+	if err == nil {
+		t.Fatal("duplicate Register: expected error, got nil")
+	}
+}
+
+func TestRegistry_GetMissing(t *testing.T) {
+	r := NewRegistry()
+	if _, ok := r.Get("missing"); ok {
+		t.Fatal("Get(missing): expected not found, got capability")
+	}
+}
+
+func TestRegistry_AllDeterministic(t *testing.T) {
+	r := NewRegistry()
+	for _, id := range []ID{"c", "a", "b"} {
+		if err := r.Register(newStub(id, KindTool)); err != nil {
+			t.Fatalf("Register %q: %v", id, err)
+		}
+	}
+	all := r.All()
+	if len(all) != 3 {
+		t.Fatalf("All: want 3, got %d", len(all))
+	}
+	got := []ID{all[0].Manifest().ID, all[1].Manifest().ID, all[2].Manifest().ID}
+	want := []ID{"a", "b", "c"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("All order: want %v, got %v", want, got)
+		}
+	}
+}
+
+func TestRegistry_ByKind(t *testing.T) {
+	r := NewRegistry()
+	must := func(c Capability) {
+		if err := r.Register(c); err != nil {
+			t.Fatalf("Register %q: %v", c.Manifest().ID, err)
+		}
+	}
+	must(newStub("bash", KindTool))
+	must(newStub("grep", KindTool))
+	must(newStub("commit-push", KindSkill))
+	must(newStub("xpost", KindApp))
+
+	tools := r.ByKind(KindTool)
+	if len(tools) != 2 {
+		t.Fatalf("ByKind(Tool): want 2, got %d", len(tools))
+	}
+	if tools[0].Manifest().ID != "bash" || tools[1].Manifest().ID != "grep" {
+		t.Fatalf("ByKind(Tool) order: got %q,%q", tools[0].Manifest().ID, tools[1].Manifest().ID)
+	}
+
+	skills := r.ByKind(KindSkill)
+	if len(skills) != 1 || skills[0].Manifest().ID != "commit-push" {
+		t.Fatalf("ByKind(Skill): got %+v", skills)
+	}
+
+	apps := r.ByKind(KindApp)
+	if len(apps) != 1 || apps[0].Manifest().ID != "xpost" {
+		t.Fatalf("ByKind(App): got %+v", apps)
+	}
+}
+
+func TestRegistry_ConcurrentRegister(t *testing.T) {
+	r := NewRegistry()
+	const n = 64
+	var wg sync.WaitGroup
+	wg.Add(n)
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		id := ID(byteID(i))
+		go func(id ID) {
+			defer wg.Done()
+			if err := r.Register(newStub(id, KindTool)); err != nil {
+				errs <- err
+			}
+		}(id)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Register: %v", err)
+		}
+	}
+	if r.Len() != n {
+		t.Fatalf("Len after concurrent register: want %d, got %d", n, r.Len())
+	}
+}
+
+func byteID(i int) string {
+	// Deterministic unique IDs without fmt.
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+	n := len(letters)
+	if i < n {
+		return string(letters[i]) + "0"
+	}
+	return string(letters[i/n]) + string(letters[i%n])
+}
+
+// Sanity: ensure stubCap satisfies Capability at compile time.
+var _ Capability = stubCap{}
+
+// Sanity: Execute returns the stub's data.
+func TestStubExecute(t *testing.T) {
+	c := newStub("x", KindTool)
+	out, err := c.Execute(context.Background(), Input{"k": "v"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.Data != "ok" {
+		t.Fatalf("Execute data: got %v", out.Data)
+	}
+}

--- a/internal/tooling/capability_adapter.go
+++ b/internal/tooling/capability_adapter.go
@@ -1,0 +1,69 @@
+package tooling
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/alamparelli/alf/internal/capability"
+)
+
+// nativeCapability adapts a NativeTool to the capability.Capability contract.
+// It lives in tooling/ (not capability/) to keep the dependency edge
+// capability ← tooling — capability must not import tooling.
+//
+// During Step 2 (#338 / C1) this adapter is dual-registered alongside the
+// legacy NativeTool entry in tooling.Registry so consumers can migrate one
+// at a time. The adapter disappears once KindTool natives live natively in
+// capability/.
+type nativeCapability struct {
+	tool NativeTool
+}
+
+// asCapability wraps a NativeTool. It is package-internal because external
+// code should consume capabilities via capability.Registry, not construct
+// adapters directly.
+func asCapability(t NativeTool) capability.Capability {
+	return nativeCapability{tool: t}
+}
+
+func (n nativeCapability) Manifest() capability.Manifest {
+	s := n.tool.Schema()
+	return capability.Manifest{
+		ID:          capability.ID(n.tool.ToolName()),
+		Kind:        capability.KindTool,
+		Name:        s.Name,
+		Description: s.Description,
+		// Version and Permissions are intentionally zero — native tools
+		// do not carry either today. They are filled in later sub-tickets
+		// (C3 brings PermissionSet; version comes from the Manifest spec).
+	}
+}
+
+func (n nativeCapability) Permissions() capability.PermissionSet {
+	return capability.PermissionSet{}
+}
+
+// Execute marshals Input to JSON (preserving the native tool's argsJSON
+// contract) and wraps the string result in capability.Output.
+//
+// Error handling mirrors NativeTool.Run: a non-nil error is returned as-is
+// from Execute, with Output zeroed. Callers that want the legacy "string +
+// error" shape stay on NativeTool during C1.
+func (n nativeCapability) Execute(ctx context.Context, in capability.Input) (capability.Output, error) {
+	var argsJSON string
+	if in == nil {
+		argsJSON = "{}"
+	} else {
+		b, err := json.Marshal(in)
+		if err != nil {
+			return capability.Output{}, fmt.Errorf("capability: marshal input: %w", err)
+		}
+		argsJSON = string(b)
+	}
+	out, err := n.tool.Run(ctx, argsJSON)
+	if err != nil {
+		return capability.Output{}, err
+	}
+	return capability.Output{Data: out}, nil
+}

--- a/internal/tooling/capability_adapter_test.go
+++ b/internal/tooling/capability_adapter_test.go
@@ -1,0 +1,149 @@
+package tooling
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/alamparelli/alf/internal/capability"
+)
+
+// fakeNative is a minimal NativeTool for adapter tests.
+type fakeNative struct {
+	name string
+	desc string
+	run  func(ctx context.Context, argsJSON string) (string, error)
+}
+
+func (f fakeNative) ToolName() string { return f.name }
+func (f fakeNative) Schema() ToolSchema {
+	return ToolSchema{Name: f.name, Description: f.desc}
+}
+func (f fakeNative) Run(ctx context.Context, argsJSON string) (string, error) {
+	return f.run(ctx, argsJSON)
+}
+
+func TestAdapter_ManifestFromSchema(t *testing.T) {
+	nt := fakeNative{name: "bash", desc: "run a shell"}
+	c := asCapability(nt)
+	m := c.Manifest()
+	if m.ID != capability.ID("bash") {
+		t.Fatalf("ID: got %q", m.ID)
+	}
+	if m.Kind != capability.KindTool {
+		t.Fatalf("Kind: got %v", m.Kind)
+	}
+	if m.Name != "bash" || m.Description != "run a shell" {
+		t.Fatalf("Manifest name/desc: got %+v", m)
+	}
+}
+
+func TestAdapter_ExecuteMarshalsInput(t *testing.T) {
+	var seen string
+	nt := fakeNative{
+		name: "echo",
+		run: func(_ context.Context, argsJSON string) (string, error) {
+			seen = argsJSON
+			return "hi", nil
+		},
+	}
+	c := asCapability(nt)
+	out, err := c.Execute(context.Background(), capability.Input{"x": 1, "y": "two"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.Data != "hi" {
+		t.Fatalf("Output.Data: got %v", out.Data)
+	}
+	if !strings.Contains(seen, `"x":1`) || !strings.Contains(seen, `"y":"two"`) {
+		t.Fatalf("argsJSON: got %q", seen)
+	}
+}
+
+func TestAdapter_ExecuteNilInput(t *testing.T) {
+	var seen string
+	nt := fakeNative{
+		name: "noargs",
+		run: func(_ context.Context, argsJSON string) (string, error) {
+			seen = argsJSON
+			return "", nil
+		},
+	}
+	if _, err := asCapability(nt).Execute(context.Background(), nil); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if seen != "{}" {
+		t.Fatalf("nil Input should marshal as {}; got %q", seen)
+	}
+}
+
+func TestAdapter_ExecutePropagatesError(t *testing.T) {
+	boom := errors.New("boom")
+	nt := fakeNative{
+		name: "fail",
+		run: func(_ context.Context, _ string) (string, error) {
+			return "", boom
+		},
+	}
+	_, err := asCapability(nt).Execute(context.Background(), capability.Input{})
+	if !errors.Is(err, boom) {
+		t.Fatalf("Execute error: want boom, got %v", err)
+	}
+}
+
+func TestRegistry_DualRegisterOnAttachAfter(t *testing.T) {
+	tmp := t.TempDir()
+	reg := NewRegistry(tmp)
+	reg.RegisterNative(fakeNative{name: "a", run: func(_ context.Context, _ string) (string, error) { return "", nil }})
+	reg.RegisterNative(fakeNative{name: "b", run: func(_ context.Context, _ string) (string, error) { return "", nil }})
+
+	cr := capability.NewRegistry()
+	reg.SetCapabilityRegistry(cr)
+
+	if cr.Len() != 2 {
+		t.Fatalf("back-fill: want 2, got %d", cr.Len())
+	}
+	if _, ok := cr.Get("a"); !ok {
+		t.Fatal("missing a")
+	}
+	if _, ok := cr.Get("b"); !ok {
+		t.Fatal("missing b")
+	}
+}
+
+func TestRegistry_DualRegisterOnAttachBefore(t *testing.T) {
+	tmp := t.TempDir()
+	reg := NewRegistry(tmp)
+	cr := capability.NewRegistry()
+	reg.SetCapabilityRegistry(cr)
+
+	reg.RegisterNative(fakeNative{name: "c", run: func(_ context.Context, _ string) (string, error) { return "ok", nil }})
+
+	got, ok := cr.Get("c")
+	if !ok {
+		t.Fatal("c not mirrored")
+	}
+	if got.Manifest().Kind != capability.KindTool {
+		t.Fatalf("Kind: got %v", got.Manifest().Kind)
+	}
+	out, err := got.Execute(context.Background(), capability.Input{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.Data != "ok" {
+		t.Fatalf("Execute data: %v", out.Data)
+	}
+}
+
+func TestRegistry_CapabilityRegistryAccessor(t *testing.T) {
+	reg := NewRegistry(t.TempDir())
+	if reg.CapabilityRegistry() != nil {
+		t.Fatal("want nil before SetCapabilityRegistry")
+	}
+	cr := capability.NewRegistry()
+	reg.SetCapabilityRegistry(cr)
+	if reg.CapabilityRegistry() != cr {
+		t.Fatal("accessor should return attached registry")
+	}
+}

--- a/internal/tooling/registry.go
+++ b/internal/tooling/registry.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/alamparelli/alf/internal/capability"
 )
 
 //go:embed ruleset.json
@@ -28,6 +30,11 @@ type Registry struct {
 	dataDir     string
 	secWarnings []SecurityWarning
 	Integrity   *IntegrityGuard // optional: skip quarantined tools from scan
+
+	// capReg is the unified capability registry. When non-nil, every
+	// RegisterNative call also registers the tool as a KindTool Capability.
+	// Introduced by #338 C1 (dual-registration). Consumers migrate in C2.
+	capReg *capability.Registry
 }
 
 // NewRegistry scans tools.d/*.json and tools/*.json under dataDir for tool manifests.
@@ -238,6 +245,9 @@ func (r *Registry) Get(name string) (ToolSchema, bool) {
 }
 
 // RegisterNative adds a native Go tool's schema and instance to the registry.
+// If a capability.Registry has been attached via SetCapabilityRegistry, the
+// tool is also mirrored there as a KindTool Capability (dual-registration
+// during #338 C1).
 func (r *Registry) RegisterNative(t NativeTool) {
 	r.schemas[t.ToolName()] = t.Schema()
 	if r.natives == nil {
@@ -245,6 +255,40 @@ func (r *Registry) RegisterNative(t NativeTool) {
 	}
 	r.natives[t.ToolName()] = t
 	r.nativeNames = append(r.nativeNames, t.ToolName())
+
+	if r.capReg != nil {
+		if err := r.capReg.Register(asCapability(t)); err != nil {
+			log.Printf("tooling: capability dual-register %q: %v", t.ToolName(), err)
+		}
+	}
+}
+
+// SetCapabilityRegistry attaches a unified capability.Registry. Future
+// RegisterNative calls will mirror the tool into it, and every previously
+// registered native tool is back-filled immediately so the two registries
+// stay in sync regardless of call order.
+func (r *Registry) SetCapabilityRegistry(cr *capability.Registry) {
+	r.capReg = cr
+	if cr == nil {
+		return
+	}
+	for _, name := range r.nativeNames {
+		t, ok := r.natives[name]
+		if !ok {
+			continue
+		}
+		if _, exists := cr.Get(capability.ID(name)); exists {
+			continue
+		}
+		if err := cr.Register(asCapability(t)); err != nil {
+			log.Printf("tooling: capability back-fill %q: %v", name, err)
+		}
+	}
+}
+
+// CapabilityRegistry returns the attached unified registry, or nil.
+func (r *Registry) CapabilityRegistry() *capability.Registry {
+	return r.capReg
 }
 
 // GetNative returns a native tool by name, or nil if not found.


### PR DESCRIPTION
## Summary

First sub-PR of **#338 (Step 2: Capability unification)** — C1.

- Introduces `internal/capability/Registry`: thread-safe, ID-keyed catalog backing the future unified dispatch path (Tools + Skills + Apps).
- Adds `nativeCapability` adapter in `internal/tooling/` so every `NativeTool` is published as a `KindTool` `Capability` via dual-registration.
- `tooling.Registry` gains `SetCapabilityRegistry` (back-fills existing natives so call ordering is irrelevant). Legacy `NativeTool` surface untouched — consumers migrate in C2.

## Baseline

> Entry: `make regression` + `make regression-race` green on HEAD.
> Exit: same, coverage for moved packages not below floor.

| Package | Before | After | Floor |
|---|---:|---:|---:|
| `internal/capability` | — | 100.0 % | — (new) |
| `internal/tooling` | 66.7 % | 66.9 % | 66.7 % |
| `internal/skills` | 75.7 % | 75.7 % | 75.7 % |
| `internal/marketplace` | 70.5 % | 70.5 % | 70.5 % |

## Test plan

- [x] `make regression` PASS
- [x] `make regression-race` PASS
- [x] Adapter tests cover: manifest mapping, Input→JSON marshal, nil Input, error propagation, dual-register before/after attach, back-fill

Refs #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)