### PR TITLE
refactor(memory,controlcenter): restore memory purity + drop handler_tiers hot-path scan (#341)

### DIFF
--- a/internal/comms/reaction.go
+++ b/internal/comms/reaction.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/alamparelli/alf/internal/memory"
+	"github.com/alamparelli/alf/internal/memory/curation"
 	"github.com/alamparelli/alf/internal/mood"
 	provider "github.com/alamparelli/alf/internal/ai/provider"
 )
@@ -162,10 +163,20 @@ Rules:
 
 	memory.AppendPreference(e.ContextDir, learning.Learning, sentiment, emoji)
 
-	// Consolidate if threshold exceeded.
-	if memory.CountEntries(e.ContextDir) >= 20 {
+	// Consolidate if threshold exceeded. memory/ no longer imports ai/provider;
+	// we wrap the provider call in a closure so curation stays provider-agnostic.
+	if memory.CountEntries(e.ContextDir) >= memory.PreferencesThreshold {
 		model := e.resolveFallbackModel()
-		go memory.ConsolidatePreferences(e.ContextDir, prov, model)
+		go curation.ConsolidatePreferences(e.ContextDir, func(ctx context.Context, prompt string) (string, error) {
+			result, err := prov.Invoke(ctx, prompt, provider.Params{
+				Model:    model,
+				MaxTurns: 1,
+			}, nil)
+			if err != nil {
+				return "", err
+			}
+			return result.Text, nil
+		})
 	}
 }
 

--- a/internal/controlcenter/factory.go
+++ b/internal/controlcenter/factory.go
@@ -179,7 +179,6 @@ func HandlerFactory(deps Deps) Handlers {
 	mux.Handle("/api/tiers", &TiersHandler{
 		TierStore:    deps.TierStore,
 		Notifier:     deps.Notifier,
-		DataDir:      deps.DataDir,
 		ToolRegistry: deps.ToolRegistry,
 		ModelCache:   deps.ModelCache,
 		EventBroker:  deps.EventBroker,

--- a/internal/controlcenter/handler_tiers.go
+++ b/internal/controlcenter/handler_tiers.go
@@ -15,9 +15,8 @@ import (
 type TiersHandler struct {
 	TierStore    TierStore
 	Notifier     Notifier
-	DataDir      string             // for tool discovery
-	ToolRegistry *tooling.Registry  // may be nil
-	ModelCache   *ModelCache        // may be nil - pre-fetched models per backend
+	ToolRegistry *tooling.Registry // may be nil — when nil the "available_tools" list falls back to cliTools only
+	ModelCache   *ModelCache       // may be nil - pre-fetched models per backend
 	EventBroker  *EventBroker
 }
 
@@ -60,17 +59,13 @@ func (h *TiersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				backends = append(backends, b)
 			}
 		}
-		// Build tool list: CLI tools + ALF tools.
+		// Build tool list: CLI tools + ALF tools. ToolRegistry is wired by the
+		// daemon bootstrap (cmd/alf-daemon/main.go) through factory.go; when it
+		// is unexpectedly nil the tab shows only the CLI subset rather than
+		// triggering a fresh disk scan on every request.
 		tools := append([]toolInfo{}, cliTools...)
 		if h.ToolRegistry != nil {
-			// Native Go tools + user tools with JSON schemas - curated list only.
-			// Only tools with a JSON schema - LLMs need a definition to invoke them.
 			for _, schema := range h.ToolRegistry.AllSchemas() {
-				tools = append(tools, toolInfo{Name: schema.Name, Desc: schema.Description, Source: "alf"})
-			}
-		} else if h.DataDir != "" {
-			// Fallback when no registry: only show tools with a JSON schema.
-			for _, schema := range tooling.NewRegistry(h.DataDir).AllSchemas() {
 				tools = append(tools, toolInfo{Name: schema.Name, Desc: schema.Description, Source: "alf"})
 			}
 		}

--- a/internal/memory/curation/preferences.go
+++ b/internal/memory/curation/preferences.go
@@ -1,0 +1,114 @@
+package curation
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/alamparelli/alf/internal/memory"
+)
+
+// PrefInvoker is the minimal LLM call shape curation needs to rewrite the
+// preferences file. Callers wrap whatever provider they own into this closure
+// so curation stays free of ai/provider imports.
+type PrefInvoker func(ctx context.Context, prompt string) (string, error)
+
+// ConsolidatePreferences asks the LLM (via invoke) to summarise the preferences
+// file when its entry count reaches memory.PreferencesThreshold. If invoke
+// returns an error or the output doesn't look like the expected markdown, the
+// file is left untouched.
+//
+// Moved out of the memory/ package in v0.7.9 to enforce the "memory must not
+// import ai" rule from technical/ARCHITECTURE-v0.7.10.md §2.2.
+func ConsolidatePreferences(contextDir string, invoke PrefInvoker) {
+	if invoke == nil {
+		return
+	}
+
+	memory.LockPreferences()
+	defer memory.UnlockPreferences()
+
+	path := filepath.Join(contextDir, memory.PreferencesFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	content := string(data)
+
+	// Count entries.
+	lines := strings.Split(content, "\n")
+	count := 0
+	for _, l := range lines {
+		if strings.HasPrefix(strings.TrimSpace(l), "- [") {
+			count++
+		}
+	}
+	if count < memory.PreferencesThreshold {
+		return
+	}
+
+	log.Printf("[preferences] consolidating %d entries", count)
+
+	prompt := fmt.Sprintf(`Consolidate these user preference entries into a structured summary. Group by category (Communication, Format, Tone, Topics, Dislikes). Merge duplicates, keep specific details, remove redundancy.
+
+Current entries:
+%s
+
+Output format (markdown):
+# User Preferences
+
+Learned from reactions and feedback.
+
+## Communication
+- ...
+
+## Format
+- ...
+
+## Tone
+- ...
+
+## Topics
+- ...
+
+## Dislikes
+- ...
+
+Rules:
+- Keep only categories that have entries
+- Each bullet should be a clear, actionable preference
+- Preserve the [+] or [-] prefix to indicate positive/negative
+- If two entries contradict, keep the most recent (last in list)
+- Output ONLY the markdown, nothing else`, content)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	raw, err := invoke(ctx, prompt)
+	if err != nil {
+		log.Printf("[preferences] consolidation failed: %v", err)
+		return
+	}
+
+	summary := strings.TrimSpace(raw)
+	summary = strings.TrimPrefix(summary, "```markdown")
+	summary = strings.TrimPrefix(summary, "```")
+	summary = strings.TrimSuffix(summary, "```")
+	summary = strings.TrimSpace(summary)
+
+	if !strings.Contains(summary, "# User Preferences") {
+		log.Printf("[preferences] consolidation returned unexpected format, skipping")
+		return
+	}
+
+	if err := os.WriteFile(path, []byte(summary+"\n"), 0o644); err != nil {
+		log.Printf("[preferences] failed to write consolidated file: %v", err)
+		return
+	}
+
+	log.Printf("[preferences] consolidated %d entries into structured summary", count)
+}

--- a/internal/memory/curation/preferences_test.go
+++ b/internal/memory/curation/preferences_test.go
@@ -1,0 +1,128 @@
+package curation_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alamparelli/alf/internal/memory"
+	"github.com/alamparelli/alf/internal/memory/curation"
+)
+
+// stubInvoker captures the prompt seen by curation.ConsolidatePreferences and
+// returns a canned reply (or error). Used only by preference-consolidation tests.
+type stubInvoker struct {
+	reply string
+	err   error
+	seen  string
+}
+
+func (s *stubInvoker) Invoke(_ context.Context, prompt string) (string, error) {
+	s.seen = prompt
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.reply, nil
+}
+
+func (s *stubInvoker) Func() curation.PrefInvoker { return s.Invoke }
+
+func TestConsolidatePreferences_BelowThresholdNoOp(t *testing.T) {
+	dir := t.TempDir()
+
+	// 3 entries < memory.PreferencesThreshold (20).
+	for i := 0; i < 3; i++ {
+		memory.AppendPreference(dir, "p", "positive", "👍")
+	}
+
+	original, _ := os.ReadFile(filepath.Join(dir, memory.PreferencesFile))
+	stub := &stubInvoker{reply: "should-never-run"}
+
+	curation.ConsolidatePreferences(dir, stub.Func())
+
+	if stub.seen != "" {
+		t.Error("invoker called despite being below threshold")
+	}
+
+	after, _ := os.ReadFile(filepath.Join(dir, memory.PreferencesFile))
+	if string(after) != string(original) {
+		t.Errorf("file mutated despite no-op:\nbefore=%q\nafter=%q", string(original), string(after))
+	}
+}
+
+func TestConsolidatePreferences_AboveThresholdReplacesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	for i := 0; i < memory.PreferencesThreshold+1; i++ {
+		memory.AppendPreference(dir, "pref", "positive", "👍")
+	}
+
+	consolidated := "# User Preferences\n\n## Communication\n- [+] concise answers\n"
+	stub := &stubInvoker{reply: consolidated}
+
+	curation.ConsolidatePreferences(dir, stub.Func())
+
+	if stub.seen == "" {
+		t.Fatal("invoker was not called despite being above threshold")
+	}
+
+	got, _ := os.ReadFile(filepath.Join(dir, memory.PreferencesFile))
+	if !strings.Contains(string(got), "## Communication") {
+		t.Errorf("file not replaced with consolidated content:\n%s", string(got))
+	}
+}
+
+func TestConsolidatePreferences_StripsMarkdownFences(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < memory.PreferencesThreshold+1; i++ {
+		memory.AppendPreference(dir, "pref", "positive", "👍")
+	}
+
+	fenced := "```markdown\n# User Preferences\n\n## Tone\n- [+] direct\n```"
+	stub := &stubInvoker{reply: fenced}
+
+	curation.ConsolidatePreferences(dir, stub.Func())
+
+	got, _ := os.ReadFile(filepath.Join(dir, memory.PreferencesFile))
+	if strings.Contains(string(got), "```") {
+		t.Errorf("markdown fences leaked into file:\n%s", string(got))
+	}
+	if !strings.Contains(string(got), "## Tone") {
+		t.Errorf("content dropped:\n%s", string(got))
+	}
+}
+
+func TestConsolidatePreferences_RejectsUnexpectedFormat(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < memory.PreferencesThreshold+1; i++ {
+		memory.AppendPreference(dir, "pref", "positive", "👍")
+	}
+	original, _ := os.ReadFile(filepath.Join(dir, memory.PreferencesFile))
+
+	stub := &stubInvoker{reply: "lorem ipsum without the expected header"}
+	curation.ConsolidatePreferences(dir, stub.Func())
+
+	after, _ := os.ReadFile(filepath.Join(dir, memory.PreferencesFile))
+	if string(after) != string(original) {
+		t.Errorf("file replaced with invalid format:\n%s", string(after))
+	}
+}
+
+func TestConsolidatePreferences_InvokerErrorLeavesFileUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < memory.PreferencesThreshold+1; i++ {
+		memory.AppendPreference(dir, "pref", "positive", "👍")
+	}
+	original, _ := os.ReadFile(filepath.Join(dir, memory.PreferencesFile))
+
+	stub := &stubInvoker{err: errors.New("llm unreachable")}
+	curation.ConsolidatePreferences(dir, stub.Func())
+
+	after, _ := os.ReadFile(filepath.Join(dir, memory.PreferencesFile))
+	if string(after) != string(original) {
+		t.Errorf("invoker error should preserve file, got:\n%s", string(after))
+	}
+}

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -1,36 +1,18 @@
 package memory
 
 import (
-	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	provider "github.com/alamparelli/alf/internal/ai/provider"
 )
 
 // Regression lock for step 1 (memory consolidation) of milestone
 // 0.7.9. Tests the public entry points: prompt collection variants,
-// onboarding flag lifecycle, preferences consolidation, workspace
-// summary, tool reminder. See TEST-BASELINE.md.
-
-// ----- Stub provider ---------------------------------------------------
-
-type stubProvider struct {
-	reply string
-	err   error
-	seen  string
-}
-
-func (s *stubProvider) Invoke(_ context.Context, prompt string, _ provider.Params, _ provider.OnProgress) (*provider.Result, error) {
-	s.seen = prompt
-	if s.err != nil {
-		return nil, s.err
-	}
-	return &provider.Result{Text: s.reply}, nil
-}
+// onboarding flag lifecycle, workspace summary, tool reminder.
+// See TEST-BASELINE.md. Preference-consolidation tests moved to
+// internal/memory/curation/preferences_test.go when the LLM-driven
+// consolidator left the memory package (0.7.9 cleanup).
 
 // ----- CollectPrompts --------------------------------------------------
 
@@ -297,102 +279,3 @@ func TestWorkspaceSummary_UnreadableDirDegrades(t *testing.T) {
 	}
 }
 
-// ----- ConsolidatePreferences ------------------------------------------
-
-func TestConsolidatePreferences_BelowThresholdNoOp(t *testing.T) {
-	dir := t.TempDir()
-
-	// 3 entries < consolidateThreshold (20).
-	for i := 0; i < 3; i++ {
-		AppendPreference(dir, "p", "positive", "👍")
-	}
-
-	original, _ := os.ReadFile(filepath.Join(dir, preferencesFile))
-	stub := &stubProvider{reply: "should-never-run"}
-
-	ConsolidatePreferences(dir, stub, "test-model")
-
-	if stub.seen != "" {
-		t.Error("provider invoked despite being below threshold")
-	}
-
-	after, _ := os.ReadFile(filepath.Join(dir, preferencesFile))
-	if string(after) != string(original) {
-		t.Errorf("file mutated despite no-op:\nbefore=%q\nafter=%q", string(original), string(after))
-	}
-}
-
-func TestConsolidatePreferences_AboveThresholdReplacesFile(t *testing.T) {
-	dir := t.TempDir()
-
-	// Push above threshold.
-	for i := 0; i < consolidateThreshold+1; i++ {
-		AppendPreference(dir, "pref", "positive", "👍")
-	}
-
-	consolidated := "# User Preferences\n\n## Communication\n- [+] concise answers\n"
-	stub := &stubProvider{reply: consolidated}
-
-	ConsolidatePreferences(dir, stub, "test-model")
-
-	if stub.seen == "" {
-		t.Fatal("provider was not invoked despite being above threshold")
-	}
-
-	got, _ := os.ReadFile(filepath.Join(dir, preferencesFile))
-	if !strings.Contains(string(got), "## Communication") {
-		t.Errorf("file not replaced with consolidated content:\n%s", string(got))
-	}
-}
-
-func TestConsolidatePreferences_StripsMarkdownFences(t *testing.T) {
-	dir := t.TempDir()
-	for i := 0; i < consolidateThreshold+1; i++ {
-		AppendPreference(dir, "pref", "positive", "👍")
-	}
-
-	fenced := "```markdown\n# User Preferences\n\n## Tone\n- [+] direct\n```"
-	stub := &stubProvider{reply: fenced}
-
-	ConsolidatePreferences(dir, stub, "test-model")
-
-	got, _ := os.ReadFile(filepath.Join(dir, preferencesFile))
-	if strings.Contains(string(got), "```") {
-		t.Errorf("markdown fences leaked into file:\n%s", string(got))
-	}
-	if !strings.Contains(string(got), "## Tone") {
-		t.Errorf("content dropped:\n%s", string(got))
-	}
-}
-
-func TestConsolidatePreferences_RejectsUnexpectedFormat(t *testing.T) {
-	dir := t.TempDir()
-	for i := 0; i < consolidateThreshold+1; i++ {
-		AppendPreference(dir, "pref", "positive", "👍")
-	}
-	original, _ := os.ReadFile(filepath.Join(dir, preferencesFile))
-
-	stub := &stubProvider{reply: "lorem ipsum without the expected header"}
-	ConsolidatePreferences(dir, stub, "test-model")
-
-	after, _ := os.ReadFile(filepath.Join(dir, preferencesFile))
-	if string(after) != string(original) {
-		t.Errorf("file replaced with invalid format:\n%s", string(after))
-	}
-}
-
-func TestConsolidatePreferences_ProviderErrorLeavesFileUnchanged(t *testing.T) {
-	dir := t.TempDir()
-	for i := 0; i < consolidateThreshold+1; i++ {
-		AppendPreference(dir, "pref", "positive", "👍")
-	}
-	original, _ := os.ReadFile(filepath.Join(dir, preferencesFile))
-
-	stub := &stubProvider{err: errors.New("llm unreachable")}
-	ConsolidatePreferences(dir, stub, "test-model")
-
-	after, _ := os.ReadFile(filepath.Join(dir, preferencesFile))
-	if string(after) != string(original) {
-		t.Errorf("provider error should preserve file, got:\n%s", string(after))
-	}
-}

--- a/internal/memory/preferences.go
+++ b/internal/memory/preferences.go
@@ -2,32 +2,33 @@ package memory
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
-
-	provider "github.com/alamparelli/alf/internal/ai/provider"
 )
 
-const (
-	preferencesFile       = "preferences.md"
-	consolidateThreshold  = 20 // consolidate after this many entries
-)
+// PreferencesFile is the on-disk file name, relative to the context directory,
+// where user preference entries are appended.
+const PreferencesFile = "preferences.md"
+
+// PreferencesThreshold is the entry count above which curation.ConsolidatePreferences
+// replaces the append-only list with a structured LLM summary.
+const PreferencesThreshold = 20
 
 var preferencesMu sync.Mutex
 
 // AppendPreference adds a learning to the preferences file.
-// If the file exceeds the threshold, it triggers consolidation.
+// If the file exceeds the threshold, callers should schedule consolidation via
+// curation.ConsolidatePreferences (memory keeps the data plane, curation
+// owns the LLM-driven reorganisation).
 func AppendPreference(contextDir string, learning, sentiment, emoji string) {
 	preferencesMu.Lock()
 	defer preferencesMu.Unlock()
 
-	path := filepath.Join(contextDir, preferencesFile)
+	path := filepath.Join(contextDir, PreferencesFile)
 
 	// Create file with header if it doesn't exist.
 	if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -54,7 +55,7 @@ func AppendPreference(contextDir string, learning, sentiment, emoji string) {
 
 // CountEntries returns the number of bullet entries in the preferences file.
 func CountEntries(contextDir string) int {
-	path := filepath.Join(contextDir, preferencesFile)
+	path := filepath.Join(contextDir, PreferencesFile)
 	f, err := os.Open(path)
 	if err != nil {
 		return 0
@@ -71,92 +72,8 @@ func CountEntries(contextDir string) int {
 	return count
 }
 
-// ConsolidatePreferences uses an LLM to summarize preferences when they exceed the threshold.
-// It replaces the file with a structured summary.
-func ConsolidatePreferences(contextDir string, prov provider.Provider, model string) {
-	preferencesMu.Lock()
-	defer preferencesMu.Unlock()
-
-	path := filepath.Join(contextDir, preferencesFile)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return
-	}
-	content := string(data)
-
-	// Count entries.
-	lines := strings.Split(content, "\n")
-	count := 0
-	for _, l := range lines {
-		if strings.HasPrefix(strings.TrimSpace(l), "- [") {
-			count++
-		}
-	}
-	if count < consolidateThreshold {
-		return
-	}
-
-	log.Printf("[preferences] consolidating %d entries", count)
-
-	prompt := fmt.Sprintf(`Consolidate these user preference entries into a structured summary. Group by category (Communication, Format, Tone, Topics, Dislikes). Merge duplicates, keep specific details, remove redundancy.
-
-Current entries:
-%s
-
-Output format (markdown):
-# User Preferences
-
-Learned from reactions and feedback.
-
-## Communication
-- ...
-
-## Format
-- ...
-
-## Tone
-- ...
-
-## Topics
-- ...
-
-## Dislikes
-- ...
-
-Rules:
-- Keep only categories that have entries
-- Each bullet should be a clear, actionable preference
-- Preserve the [+] or [-] prefix to indicate positive/negative
-- If two entries contradict, keep the most recent (last in list)
-- Output ONLY the markdown, nothing else`, content)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	result, err := prov.Invoke(ctx, prompt, provider.Params{
-		Model:    model,
-		MaxTurns: 1,
-	}, nil)
-	if err != nil {
-		log.Printf("[preferences] consolidation failed: %v", err)
-		return
-	}
-
-	summary := strings.TrimSpace(result.Text)
-	summary = strings.TrimPrefix(summary, "```markdown")
-	summary = strings.TrimPrefix(summary, "```")
-	summary = strings.TrimSuffix(summary, "```")
-	summary = strings.TrimSpace(summary)
-
-	if !strings.Contains(summary, "# User Preferences") {
-		log.Printf("[preferences] consolidation returned unexpected format, skipping")
-		return
-	}
-
-	if err := os.WriteFile(path, []byte(summary+"\n"), 0o644); err != nil {
-		log.Printf("[preferences] failed to write consolidated file: %v", err)
-		return
-	}
-
-	log.Printf("[preferences] consolidated %d entries into structured summary", count)
-}
+// LockPreferences / UnlockPreferences expose the file-level mutex to callers
+// (curation.ConsolidatePreferences) that must serialise rewrites against
+// concurrent AppendPreference calls.
+func LockPreferences()   { preferencesMu.Lock() }
+func UnlockPreferences() { preferencesMu.Unlock() }

--- a/internal/memory/preferences_test.go
+++ b/internal/memory/preferences_test.go
@@ -13,7 +13,7 @@ func TestAppendPreference(t *testing.T) {
 	AppendPreference(dir, "User likes bullet lists", "positive", "👍")
 	AppendPreference(dir, "User dislikes verbose explanations", "negative", "👎")
 
-	data, err := os.ReadFile(filepath.Join(dir, preferencesFile))
+	data, err := os.ReadFile(filepath.Join(dir, PreferencesFile))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestCountEntries(t *testing.T) {
 
 func TestAppendPreference_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, preferencesFile)
+	path := filepath.Join(dir, PreferencesFile)
 
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatal("file should not exist yet")


### PR DESCRIPTION
## Summary

Cleanup pass for milestone 0.7.9 — two targeted fixes identified during the architecture alignment audit:

1. **Memory purity restored** — `ConsolidatePreferences` moved out of `internal/memory/` into `internal/memory/curation/` with a closure-based `PrefInvoker` signature, so `memory/` no longer imports `ai/provider` (ARCHITECTURE-v0.7.10.md §2.2).
2. **handler_tiers.go hot-path scan removed** — each GET /api/tiers was rebuilding a full `tooling.NewRegistry(dataDir)` inline (disk scan) when `h.ToolRegistry` was unexpectedly nil. The daemon bootstrap always wires it; the fallback is dead code in prod.

Also refactored 5 consolidation tests into `memory/curation/preferences_test.go` with a PrefInvoker-shaped stub.

See full ticket comment: #341 (comment).

## Test plan

- [x] `go build ./...` clean
- [x] `make regression` green, coverage **48.2 %** (floor #343: 47.0 %)
- [x] `TestFoundationDependencyRules` (enforcing) — PASS
- [x] `TestConsumerDependencyRules` (enforcing) — PASS
- [x] `TestHardcodedModelFallback` — 0 violations / 257 files

## What this does NOT touch

- Sandbox facet wire-in (central promise §2.4) — moves to 0.8.0.
- `tooling/` / `skills/` / `marketplace/` as packages — they're specialized sources feeding `capability.Registry`, not duplicated registries. See the detailed analysis in #341 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)