### PR TITLE
refactor(envsecrets): rename internal/secrets → internal/envsecrets (#341)

### DIFF
--- a/cmd/alf-daemon/config.go
+++ b/cmd/alf-daemon/config.go
@@ -14,7 +14,7 @@ import (
 	cc "github.com/alamparelli/alf/internal/controlcenter"
 	firewall "github.com/alamparelli/alf/internal/sandbox/network"
 	provider "github.com/alamparelli/alf/internal/ai/provider"
-	"github.com/alamparelli/alf/internal/secrets"
+	"github.com/alamparelli/alf/internal/envsecrets"
 	"github.com/alamparelli/alf/internal/tooling"
 	vault "github.com/alamparelli/alf/internal/sandbox/secrets"
 )
@@ -31,7 +31,7 @@ func readAuthToken() string {
 		}
 	}
 	// Fallback: Docker secret (for backwards compatibility / migration).
-	return secrets.ReadSecret("CC_AUTH_TOKEN")
+	return envsecrets.ReadSecret("CC_AUTH_TOKEN")
 }
 
 // vaultPassword reads the master password from the persisted password file

--- a/cmd/alf-daemon/main.go
+++ b/cmd/alf-daemon/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/alamparelli/alf/internal/comms"
 	firewall "github.com/alamparelli/alf/internal/sandbox/network"
 	"github.com/alamparelli/alf/internal/marketplace"
-	"github.com/alamparelli/alf/internal/secrets"
+	"github.com/alamparelli/alf/internal/envsecrets"
 	vault "github.com/alamparelli/alf/internal/sandbox/secrets"
 	cc "github.com/alamparelli/alf/internal/controlcenter"
 	"github.com/alamparelli/alf/internal/eventlog"
@@ -410,7 +410,7 @@ func main() {
 
 	// Voice transcriber (HTTP client to whisper-service container).
 	whisperURL := os.Getenv("WHISPER_URL")
-	whisperSecret := secrets.ReadSecret("WHISPER_SHARED_SECRET")
+	whisperSecret := envsecrets.ReadSecret("WHISPER_SHARED_SECRET")
 	var transcriber *voice.Transcriber
 	if whisperURL != "" && whisperSecret != "" {
 		instanceID, _ := os.Hostname()
@@ -2256,7 +2256,7 @@ func resolveEmbedder(tierStore cc.TierStore) memory.Embedder {
 	// embed-server token map. Docker hostnames change on every container restart,
 	// which would leak slots and eventually hit the 50-instance cap.
 	const embedInstanceID = "alf-daemon"
-	secret := secrets.ReadSecret("EMBED_SHARED_SECRET")
+	secret := envsecrets.ReadSecret("EMBED_SHARED_SECRET")
 
 	if tc := tierStore.Current(); tc != nil {
 		// 1. New: memory.embedding config.

--- a/cmd/extract-video/main.go
+++ b/cmd/extract-video/main.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alamparelli/alf/internal/secrets"
+	"github.com/alamparelli/alf/internal/envsecrets"
 	"github.com/alamparelli/alf/internal/voice"
 )
 
@@ -193,7 +193,7 @@ func collectFiles(prefix string, n int) ([]string, error) {
 
 func transcribeAudio(videoPath string) (string, string) {
 	whisperURL := os.Getenv("WHISPER_URL")
-	whisperSecret := secrets.ReadSecret("WHISPER_SHARED_SECRET")
+	whisperSecret := envsecrets.ReadSecret("WHISPER_SHARED_SECRET")
 	if whisperURL == "" || whisperSecret == "" {
 		return "", ""
 	}

--- a/internal/envsecrets/envsecrets.go
+++ b/internal/envsecrets/envsecrets.go
@@ -1,4 +1,7 @@
-package secrets
+// Package envsecrets reads sensitive configuration from environment variables,
+// with optional _FILE indirection for Docker / Kubernetes secret mounts.
+// Not to be confused with internal/sandbox/secrets (the per-app vault).
+package envsecrets
 
 import (
 	"os"


### PR DESCRIPTION
## Summary

Small naming-collision fix found during the internal/ folder assessment for #341.

`internal/secrets/` (Docker/Kubernetes env-var reader, 18 LoC, one helper) renamed to `internal/envsecrets/` to remove the clash with `internal/sandbox/secrets/` (the per-app vault). Both packages now map to distinct import identifiers everywhere.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/... ./internal/envsecrets/...` green
- [x] 4 call-sites updated (alf-daemon main.go + config.go, extract-video main.go, vault import alias kept)
- [x] No behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)