### PR TITLE
docs: refresh README + CONTRIBUTING + publish docs/ARCHITECTURE.md (#342)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,18 +14,22 @@
 # All binaries
 go build ./...
 
-# With FTS5 support (required for memstore)
+# With FTS5 support (required for memory embeddings + sqlite-vec)
 CGO_ENABLED=1 go build -tags fts5 ./...
 ```
 
 ### Test
 
 ```sh
-# All tests (except memstore)
+# All tests (except memory sub-packages using FTS5)
 go test ./...
 
-# Including memstore (requires CGO + FTS5)
+# Full regression (CGO + FTS5 required for memory/, sandbox/*, archtest)
 CGO_ENABLED=1 go test -tags fts5 ./...
+
+# Or via make:
+make regression         # same as above, with coverage report
+make regression-quick   # no coverage, faster
 ```
 
 ### Run locally
@@ -60,32 +64,100 @@ Useful flags:
 - Factory pattern for complex object creation (`internal/controlcenter/factory.go`)
 - Error messages are lowercase, no punctuation
 
-### Architecture patterns
+### Architecture — 5 blocks
 
-- **Chat engine** - `internal/comms/` owns all message processing logic. Adapters (Telegram, Control Center) call `Process()` and receive events via callbacks
-- **Provider interface** - all LLM interaction goes through `provider.Provider` and `provider.Classifier` (CLI + API implementations)
-- **Unified conversation store** - `internal/conversation/` captures rich message history (text, tool_use, tool_result, thinking) in a JSONL ring buffer, shared across all backends
-- **Chat database** - `internal/chatdb/` provides SQLite-backed persistent message storage
-- **Persistent subprocesses** - long-lived processes (classifier) follow the same pattern: mutex, stdin/stdout JSON lines, auto-restart on crash, idle timeout
-- **Whisper service** - voice transcription runs in a separate Docker container (`whisper-service`), ALF communicates via HTTP client with bearer token auth
-- **Go-native inference** - ONNX embeddings run in-process via `onnxruntime_go`, also exposed as HTTP server (`cmd/embed-server/`)
-- **Embedded core instructions** - `internal/memory/core.md` compiled into the binary via `go:embed`, injected first in every conversation
-- **Router is pure logic** - `internal/router/` builds prompts and parses responses, never spawns processes
-- **Signal system** - `internal/signal/` provides a Unix-socket server for Claude sessions to send Telegram messages/reactions. System tools (`cmd/signal`, `cmd/schedule-tools`) use this socket
-- **System tools multi-call binary** - `cmd/system-tools/` bridges CLI tool invocations (task, team, skill, app, config, tier, log, search) to the daemon's HTTP API via symlinks
-- **App supervisor** - `internal/supervisor/` manages background services declared in `apps/*/service.json` with restart policies and exponential backoff
-- **Outbound firewall** - `internal/firewall/` proxies all HTTP/HTTPS traffic from Claude subprocesses with domain-level allow/deny rules
-- **Tracing** - `internal/trace/` logs chain and task team events for observability
-- **TLS generation** - `internal/tlsgen/` generates self-signed certificates for local HTTPS installs
-- **Non-root daemon** - Daemon drops to uid 1001 (`alfd`) via setpriv, LLM subprocesses run as uid 1000 (`alf`) with zero capabilities and sanitized environment, config is read-only, tools are rx-only
+ALF's code is organised around five first-class concerns, enforced by CI:
+
+```
+internal/
+├── capability/   ← what ALF can execute       (tools + skills + apps)
+├── memory/       ← what ALF knows / remembers (conv + embeddings + preferences)
+├── ai/           ← the brain that decides     (provider + strategy + ResolveModel)
+├── sandbox/      ← the guards that enforce    (firewall + vault + filesystem + integrity)
+└── runtime/      ← the conductor              (orchestrates the four)
+```
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full reference, sub-package layout, and contract interfaces. What follows is the contributor-facing summary.
+
+#### Where does my new file belong?
+
+Use this decision tree when adding a new file or package:
+
+1. **Is it executable by the AI (a tool, skill, or app)?**
+   → `internal/capability/` contract + register through the adapter in `tooling/`, `skills/`, or `marketplace/`.
+
+2. **Does it persist or recall data (conversations, embeddings, preferences, facts)?**
+   → `internal/memory/` (or a sub-package: `memory/embed/`, `memory/curation/`, `memory/dedup/`, …).
+
+3. **Does it turn an intent into tokens (provider driver, strategy, model resolution)?**
+   → `internal/ai/` (contract) or `internal/ai/provider/` (concrete driver).
+
+4. **Does it enforce a policy (file access, network, secrets, integrity)?**
+   → `internal/sandbox/` (or a facet sub-package: `sandbox/exec/`, `sandbox/network/`, `sandbox/secrets/`, `sandbox/integrity/`).
+
+5. **Does it orchestrate the four (pipelines, agents, classifier)?**
+   → `internal/runtime/` (or `runtime/agents/` for multi-agent, `runtime/classifier/` for tier selection).
+
+6. **Is it a user-facing surface (CLI, web UI, Telegram, voice, scheduler)?**
+   → root-level consumer package: `cli/`, `controlcenter/`, `telegram/`, `voice/`, `scheduler/`.
+
+7. **Is it ops plumbing (cron, tracing, supervision, updater, cert gen, event log, …)?**
+   → `internal/platform/<name>/`.
+
+8. **None of the above?** → 🚨 **Red flag.** Open a discussion issue before you code. If a new concept doesn't fit any of the five blocks nor the periphery, either the concept is ill-framed or the architecture needs an explicit amendment — both deserve a conversation first.
+
+#### Dependency rules (enforced by CI)
+
+```
+consumers (controlcenter, telegram, scheduler, cli, ...)
+    │
+    ▼
+  runtime
+    │
+    ├──► capability
+    ├──► memory
+    ├──► ai
+    └──► sandbox
+```
+
+Forbidden imports:
+
+- `capability` **must not** import `memory`, `ai`, `sandbox`, `runtime`.
+- `memory` **must not** import `capability`, `ai`, `sandbox`, `runtime`.
+- `ai` **must not** import `capability`, `memory`, `sandbox`, `runtime`.
+- `sandbox` **must not** import `capability`, `memory`, `ai`, `runtime`.
+- **Only `runtime` may import the four blocks together.**
+- No consumer imports an inner block directly — everything goes through `runtime`.
+
+Enforcement lives in `internal/archtest/deps_test.go` (`TestFoundationDependencyRules`, `TestConsumerDependencyRules`). Both run in enforcing mode — a violation fails CI. A third test (`TestHardcodedModelFallback`) ensures `ai.ResolveModel` stays the single source of truth for model selection.
+
+Justified cross-block imports (e.g. `marketplace` → `capability` for adapter types) are listed as exceptions in the archtest and must be documented when added.
+
+#### Patterns worth knowing
+
+- **Capability adapters.** `tooling/`, `skills/`, and `marketplace/` each keep a `capability_adapter.go` that wraps their native objects (NativeTool / Skill / App) as `capability.Capability`. They register into `capability.Registry` via dual-registration. Runtime resolves Capabilities through the unified registry.
+- **Memory contract tests.** Any new `memory.Store` implementation must pass `internal/memory/memtest/` — the contract test battery guarantees scoping + idempotency invariants.
+- **Provider interface.** All LLM interaction goes through `ai.Engine` + `ai.Strategy`. Provider drivers implement `ai.Engine` inside `ai/provider/`. The runtime picks the Strategy.
+- **ONNX embeddings.** `memory/embed/` wraps `onnxruntime_go` in-process. `cmd/embed-server/` exposes the same embedder over HTTP for cases where CGO is unavailable.
+- **`go:embed` core prompts.** Operational prompts (`core.md`, `onboarding.md`, …) live in `internal/memory/` and are compiled into the binary via `go:embed` in `memory/prompts.go`.
+- **Persistent subprocesses.** Long-lived processes (classifier) share a pattern: mutex, stdin/stdout JSON lines, auto-restart on crash, idle timeout.
+- **Whisper sidecar.** Voice transcription runs in a separate Docker container (`whisper-service`); ALF talks to it over HTTP with bearer-token auth.
+- **Signal socket.** `internal/platform/signal/` is a Unix-socket server that lets in-sandbox Capabilities send Telegram messages / reactions. `cmd/signal` and `cmd/schedule-tools` are the clients.
+- **System-tools multi-call binary.** `cmd/system-tools/` bridges CLI subcommands (task, team, skill, app, config, tier, log, search) to the daemon's HTTP API via symlinks.
+- **App supervisor.** `internal/platform/supervisor/` manages background services declared in `apps/*/service.json` with restart policies + exponential backoff.
+- **Outbound firewall.** `internal/sandbox/network/` proxies all HTTP/HTTPS traffic from LLM subprocesses with domain-level allow/deny rules.
+- **Tracing.** `internal/platform/trace/` logs chain and task-team events for observability.
+- **Non-root daemon.** Daemon drops to uid 1001 (`alfd`) via `setpriv`; LLM subprocesses run as uid 1000 (`alf`) with zero capabilities and sanitised environment. Config is read-only, tools are rx-only.
 
 ### File organization
 
-- `cmd/` - entry points only, minimal logic (includes system tools: `schedule-tools`, `signal`, `system-tools`, `embed-server`, `nettrack-helper`)
-- `internal/` - all business logic, one package per domain
+- `cmd/` - entry points only, minimal logic (includes system tools: `schedule-tools`, `signal`, `system-tools`, `embed-server`, `nettrack-helper`, `extract-video`, `memory-tools`)
+- `internal/` - all business logic, organised into the 5 blocks + periphery (see decision tree above)
 - `scripts/` - deployment, release, and local dev automation (`dev-deploy.sh`, `dev-local.sh`, `ship.sh`)
 - `internal/controlcenter/frontend/` - Svelte 5 + Vite frontend, builds to `internal/controlcenter/web/` for `go:embed`
 - `internal/controlcenter/web/` - embedded web assets for Control Center (built output, do not edit directly)
+- `docs/` - user- and contributor-facing documentation (including `ARCHITECTURE.md`)
+- `technical/` - implementation notes, test baselines, archived specs
 
 ### Testing
 
@@ -124,10 +196,10 @@ Keep the subject line under 72 characters. Add a body if the "why" isn't obvious
 
 ALF currently supports Telegram. To add a new platform:
 
-1. Create `internal/<platform>/` with send/receive logic
-2. Add polling or webhook handler in `cmd/alf-daemon/main.go`
-3. Wire messages through the existing router - the classification and tier system is platform-agnostic
-4. Add platform-specific formatting in the new package (the router returns plain text)
+1. Create `internal/<platform>/` with send/receive logic (same level as `telegram/`, `voice/`).
+2. Add polling or webhook handler in `cmd/alf-daemon/main.go`.
+3. Consume `runtime.Runtime.Chat(ctx, convID, input)` — the classification and tier system is platform-agnostic and lives inside Runtime. Consumers do not call `ai/` / `memory/` / `capability/` directly.
+4. Add platform-specific formatting in the new package (Runtime returns plain text + structured events).
 
 ## Adding a new tool
 
@@ -171,10 +243,11 @@ ALF is built with heavy AI assistance. Here's how to work effectively with AI co
 
 ### Working with AI agents
 
-- The project follows **SOLID principles** and **factory patterns** - AI agents should maintain these
-- **TDD** - write tests first when adding new behavior
-- Keep `internal/` packages decoupled - one domain per package, interfaces at boundaries
-- System tools in `cmd/` are thin wrappers; business logic stays in `internal/`
+- Point the agent at [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) first — the 5-block model + decision tree is what keeps generated code in the right place.
+- The project follows **SOLID principles** and **factory patterns** — AI agents should maintain these.
+- **TDD** — write tests first when adding new behaviour.
+- Keep `internal/` packages decoupled — enforce the block boundaries from `internal/archtest/` in every PR.
+- System tools in `cmd/` are thin wrappers; business logic stays in `internal/`.
 
 ### Frontend (Svelte)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,7 +218,7 @@ EOF
 chmod +x /path/to/alf/data/tools/my-tool
 ```
 
-User tools are auto-discovered at boot and listed in Claude's toolbox. Claude runs them via the Bash tool.
+User tools are auto-discovered at boot and exposed to whichever backend (CLI / Codex / API / Ollama) is serving the current tier. The model invokes them through the standard tool-call protocol of its backend.
 
 ### System tools (image rebuild)
 
@@ -235,7 +235,7 @@ System tools are Go binaries baked into the Docker image at `/opt/alf/tools/`. U
    ```
 4. The daemon symlinks system tools into `data/tools.d/` at startup
 
-Existing system tools: `extract-video` (media processing), `memory-tools` (semantic memory), `schedule-tools` (cron jobs), `signal` (Telegram messaging from Claude sessions), `system-tools` (multi-call binary bridging CLI to daemon API), `embed-server` (embedding HTTP server), `nettrack-helper` (conntrack event logger).
+Existing system tools: `extract-video` (media processing), `memory-tools` (semantic memory), `schedule-tools` (cron jobs), `signal` (Telegram messaging from in-sandbox LLM sessions), `system-tools` (multi-call binary bridging CLI to daemon API), `embed-server` (embedding HTTP server), `nettrack-helper` (conntrack event logger).
 
 ## AI-assisted development
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,23 @@
 
 A personal AI assistant that lives in your Telegram chats. Built in Go. Runs on your hardware.
 
-ALF connects Claude to your messaging, wraps it with semantic long-term memory, configurable response tiers, voice transcription, and a web dashboard - all in a single Docker container you control.
+ALF connects an LLM of your choice to your messaging, wraps it with semantic long-term memory, configurable response tiers, voice transcription, and a web dashboard — all in a single Docker container you control.
 
 ## Why ALF
 
 Most AI assistant frameworks are Node.js monoliths with hundreds of dependencies. ALF is different:
 
-- **Go binary, zero JS runtime** - single static binary, minimal attack surface, no `node_modules` supply chain
-- **Semantic memory** - Go-native ONNX embeddings (sqlite-vec + FTS5) for real long-term recall, not just context window tricks
-- **Persistent classifier** - a long-lived Claude process handles message routing in ~0ms instead of spawning a new process per message
-- **Tier system** - configurable response tiers (model, tools, effort, read/write access) routed by an LLM classifier
-- **Defense-in-depth security** - Non-root daemon (uid 1001), LLM subprocess isolated as uid 1000 with zero capabilities, read-only config, restricted tool execution
-- **Multi-backend** - Claude CLI, OpenRouter, OpenAI, Ollama, or any OpenAI-compatible API. Mix backends per tier
-- **No API costs** - runs on your Claude subscription (Pro/Max/Team), not pay-per-token API calls
-- **Self-hosted** - your hardware, your data, your rules. No cloud dependency beyond your Claude account
+- **Go binary, zero JS runtime** — single static binary, minimal attack surface, no `node_modules` supply chain
+- **Semantic memory** — Go-native ONNX embeddings (sqlite-vec + FTS5) for real long-term recall, not just context window tricks
+- **Persistent classifier** — a long-lived classifier process handles message routing in ~0ms instead of spawning a new one per message
+- **Tier system** — configurable response tiers (model, tools, effort, read/write access) routed by an LLM classifier
+- **Defense-in-depth security** — non-root daemon (uid 1001), LLM subprocess isolated as uid 1000 with zero capabilities, read-only config, restricted tool execution
+- **Backend-agnostic** — three backend families, mixable per tier:
+  - **CLI**: Claude Code (Claude Pro/Max subscription) or OpenAI Codex (ChatGPT Plus + GPT-5-codex)
+  - **API**: any OpenAI-compatible HTTP API (OpenRouter for 200+ models, OpenAI, Groq, Anthropic API, …)
+  - **Local**: Ollama (any local model, no API key)
+- **Subscription-friendly** — run on a flat-rate subscription (Claude Pro/Max, ChatGPT Plus) instead of pay-per-token, or go fully local with Ollama
+- **Self-hosted** — your hardware, your data, your rules. No cloud dependency beyond whichever backend you configure
 
 ## How it works
 
@@ -49,7 +52,7 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the contributor-facing re
 - Docker and Docker Compose
 - 2 GB RAM minimum
 - *Optional:* a [Telegram bot token](https://core.telegram.org/bots#how-do-i-create-a-bot) (via @BotFather) + your chat ID
-- *Recommended:* a Claude, Codex, or OpenAI-compatible API subscription (configured via the Setup Wizard)
+- *One* of the supported backends: a Claude Pro/Max subscription (for the Claude Code CLI backend), a ChatGPT Plus subscription (for the Codex CLI backend), any OpenAI-compatible API key (OpenRouter, OpenAI, Groq, …), or a local Ollama install
 
 ### Install
 
@@ -68,14 +71,16 @@ The interactive wizard walks you through:
 2. Configuring Telegram credentials
 3. Setting up dashboard access (HTTP or HTTPS with Let's Encrypt)
 4. Starting the container
-6. Authenticating Claude
+5. Authenticating your chosen backend (Claude CLI, Codex CLI, or API key)
 
-After the container is running, the Control Center **Setup Wizard** guides you through backend selection (Claude CLI, OpenRouter, OpenAI, Ollama), tier presets, and optional Telegram configuration - all from the browser.
+After the container is running, the Control Center **Setup Wizard** guides you through backend selection (CLI, Codex, API / OpenRouter / OpenAI / Ollama / …), tier presets, and optional Telegram configuration — all from the browser.
 
 ### After setup
 
 ```sh
-alf login     # Authenticate Claude inside the container
+alf login     # Authenticate the Claude CLI backend inside the container
+              # (only needed if you picked the "cli" backend — API / Codex / Ollama
+              #  backends authenticate via keys stored in the vault)
 alf status    # Check container health
 alf logs      # Tail container logs
 ```
@@ -105,18 +110,25 @@ Define response tiers with different capabilities:
 
 | Property | What it controls |
 |----------|-----------------|
-| `model` | Claude model (haiku, sonnet, opus) |
-| `effort` | Thinking effort (low, medium, high) |
+| `backend` | Which backend serves this tier (`cli`, `codex`, or a configured API backend) |
+| `model` | Model ID for the chosen backend (e.g. `sonnet`, `gpt-4o`, `llama3`) |
+| `effort` | Thinking / reasoning effort (`low`, `medium`, `high`) |
 | `tools` | Available tools for the session |
-| `write_capable` | Whether Claude can modify files |
+| `write_capable` | Whether the model is allowed to modify files |
 | `max_turns` | Agentic loop depth |
 | `instant` | Router responds directly (no second LLM call) |
 
-The LLM classifier reads your message and picks the right tier. Greetings get instant haiku responses. Complex tasks get multi-turn opus sessions with full tool access.
+The LLM classifier reads your message and picks the right tier. Greetings get instant cheap-model responses. Complex tasks get multi-turn deep-model sessions with full tool access.
 
 ### Multi-backend support
 
-ALF isn't limited to Claude. Connect OpenRouter (200+ models), OpenAI (GPT-4), Ollama (local models), or any OpenAI-compatible API. Mix backends in the same tier configuration - route simple messages to a free model and complex tasks to Claude. Conversation context flows seamlessly across backend switches.
+ALF ships with three backend families and you can mix them per tier:
+
+- **CLI backend** — routes through a locally-installed CLI. Two providers supported: **Claude Code** (uses your Claude Pro / Max / Team subscription, flat rate) and **OpenAI Codex** (uses your ChatGPT Plus subscription with `codex exec` for GPT-5-codex).
+- **API backend** — any OpenAI-compatible HTTP endpoint. Pre-configured presets for **OpenRouter** (200+ models via a single key), **OpenAI** (GPT-4o / o1 / o3 / …), **Anthropic API** (direct Claude API), and you can register any custom `base_url`.
+- **Local backend** — **Ollama**. Any locally-hosted model, zero API key, zero cost.
+
+Conversation context flows seamlessly across backend switches — a tier running on Ollama and another running on Claude CLI can share the same conversation history. See [backends documentation](internal/controlcenter/docs/backends.md) for the full configuration reference.
 
 ### Voice transcription
 
@@ -124,10 +136,10 @@ Send a voice message on Telegram. ALF transcribes it via the whisper-service con
 
 ### Media processing
 
-- **Images** - forwarded to Claude's vision capabilities
-- **Videos/GIFs** - frame extraction into contact sheets + audio transcription
-- **PDFs** - text extraction via pdftotext
-- **Documents** - passed through to Claude with appropriate context
+- **Images** — forwarded to the model's vision capabilities (when the backend supports it)
+- **Videos/GIFs** — frame extraction into contact sheets + audio transcription
+- **PDFs** — text extraction via pdftotext
+- **Documents** — passed through to the model with appropriate context
 
 ### Skills & tools
 
@@ -201,7 +213,7 @@ alf start         Start the container
 alf stop          Stop the container
 alf restart       Restart the container
 alf upgrade       Pull latest image and restart (update alias works too)
-alf login         Authenticate Claude inside the container
+alf login         Authenticate the Claude CLI backend inside the container (only for "cli" backend; API/Codex/Ollama authenticate via the vault)
 alf status        Show container status and versions
 alf logs          Tail container logs
 alf secret        Manage secrets (list, set, remove)
@@ -257,7 +269,7 @@ cosign verify-attestation ghcr.io/alamparelli/alf:<version> \
 - **OS**: Linux or macOS (Docker required)
 - **RAM**: 512 MB minimum (2 GB recommended for voice transcription)
 - **Disk**: ~800 MB for the Docker image + ~600 MB on first voice message (Whisper model)
-- **Network**: outbound HTTPS to Telegram API and Claude API
+- **Network**: outbound HTTPS to Telegram + the API endpoint(s) of the backend(s) you've configured (Anthropic, OpenAI, OpenRouter, Ollama host, …)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,24 @@ Most AI assistant frameworks are Node.js monoliths with hundreds of dependencies
 
 **Host CLI** (`alf`) manages the container lifecycle from the host machine. Inside Docker, the **daemon** runs as `alfd` (uid 1001) and serves the Control Center web UI, polls Telegram, and coordinates all subsystems. LLM subprocesses run as `alf` (uid 1000) with restricted permissions and zero capabilities. A sidecar container handles voice transcription (faster-whisper).
 
-Messages flow through a **chat engine** (`internal/comms/`) → **router** → **LLM provider** pipeline. The router classifies intent and selects a response tier (model, tools, effort level). A **permission system** gates access to sandboxed apps and tools. Apps run in chroot-isolated namespaces with filesystem allowlists. Secrets are accessed exclusively through a **vault proxy** (Unix socket) — no direct access from app code. A **tracing system** (`internal/trace/`) logs chain and task events for observability.
+### Internal architecture — 5 blocks
+
+ALF's internal code is organised around five first-class concerns:
+
+```
+internal/
+├── capability/   ← what ALF can execute       (tools + skills + apps)
+├── memory/       ← what ALF knows / remembers (conv + embeddings + preferences)
+├── ai/           ← the brain that decides     (provider + strategy + ResolveModel)
+├── sandbox/      ← the guards that enforce    (firewall + vault + filesystem + integrity)
+└── runtime/      ← the conductor              (orchestrates the four)
+```
+
+A **Capability** (tool / skill / app) is executed by the **AI**, with graded access to **Memory**, inside a **Sandbox** that enforces a Policy. The **Runtime** orchestrates the four. Everything else is periphery (user-facing consumers under `cli/ controlcenter/ telegram/ voice/ scheduler/`, ops plumbing under `internal/platform/`).
+
+Dependency rules are enforced by CI (`internal/archtest/`): only `runtime/` may import the four inner blocks; consumers depend on `runtime/` alone.
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the contributor-facing reference and the "where do I put this?" decision tree.
 
 ## Quick start
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,322 @@
+# ALF Architecture
+
+> This is the canonical reference for ALF's internal structure.
+> Every refactor, every new feature, every PR review points back to this document.
+> Golden rule: **if a new package fits none of the 5 blocks nor the periphery, it's a red flag — open a discussion before coding.**
+
+---
+
+## 1. One-sentence description
+
+ALF is:
+
+> A **Capability** (tool / skill / app) is executed by the **AI**,
+> with graded access to **Memory**,
+> inside a **Sandbox** that enforces a Policy.
+> The **Runtime** orchestrates the four.
+
+Anything that does not directly participate in that sentence is **periphery** (plumbing, transport, UI, ops).
+
+---
+
+## 2. The 5 blocks
+
+```
+internal/
+├── capability/   ← what ALF can execute       (tools + skills + apps)
+├── memory/       ← what ALF knows / remembers (conv + embeddings + preferences)
+├── ai/           ← the brain that decides     (provider + strategy + ResolveModel)
+├── sandbox/      ← the guards that enforce    (firewall + vault + filesystem + integrity)
+└── runtime/      ← the conductor              (orchestrates the four)
+```
+
+### 2.1 `capability/`
+
+**Role.** Everything ALF can execute on the AI's behalf.
+
+**Absorbs.** `tooling/` + `skills/` + `marketplace/` (as Capability producers; the adapters live in those source packages and register into `capability.Registry`).
+
+**Minimum contract.**
+
+```go
+type Capability interface {
+    Manifest() Manifest                          // name, version, description, kind
+    Permissions() PermissionSet                  // what it declares it needs
+    Execute(ctx context.Context, in Input) (Output, error)
+}
+
+type Kind int
+const (
+    KindTool  Kind = iota // native short-lived execution (read_file, bash, grep...)
+    KindSkill             // prompt + orchestrated tools (commit-push, doc-writer...)
+    KindApp               // UI iframe + backend (xpost, contacthive...)
+)
+```
+
+**Hard rules.**
+- A Capability **never calls** another Capability directly. It returns a result; the Runtime composes.
+- A Capability **does not know** about Memory nor AI. Inputs arrive via `Input`.
+- Every Capability has a versioned Manifest and an explicit PermissionSet.
+- The Marketplace is a **Capability registry** (index + installation).
+
+### 2.2 `memory/`
+
+**Role.** Unified persistence for everything ALF knows.
+
+**Sub-packages.**
+- `memory/dedup/` — near-duplicate blocking at index time.
+- `memory/embed/` — concrete ONNX implementation of `memory.Embedder` (tokenizer included). Used by `cmd/embed-server`.
+- `memory/curation/` — fact extraction from LLM output (`Extractor`) + periodic consolidation/dedup (`Consolidator`). Also hosts `ConsolidatePreferences`, which was moved out of the memory root so the root stays free of `ai/provider` imports. These services **consume** `memory.Store`; they do not redefine the contract.
+- `memory/memtest/` — contract tests run against every `Store` implementation.
+- `memory/socketsrv/` — IPC server for the `memory-tools` binary.
+
+**Minimum contract.**
+
+```go
+type Store interface {
+    // Conversations
+    AppendMessage(ctx, convID ConvID, msg Message) error
+    ListMessages(ctx, convID ConvID, opts ListOpts) ([]Message, error)
+    Summarize(ctx, convID ConvID) (Summary, error)
+
+    // Embeddings
+    Index(ctx, scope Scope, doc Document) error
+    Search(ctx, scope Scope, query string, k int) ([]Hit, error)
+
+    // Preferences
+    GetPref(ctx, key string) (Value, error)
+    SetPref(ctx, key string, val Value) error
+}
+```
+
+**Hard rules.**
+- **Every function that touches a conversation takes `convID` as an explicit parameter.** No "current conv" hidden in a singleton.
+- One SQLite schema. `CurrentConvID` / `ActiveConvID` is a user **preference**, not a memory-state field.
+- Conv scoping is checked at the function signature, not in the body.
+- Embeddings and messages share the same `convID` when they are tied to a conv.
+
+### 2.3 `ai/`
+
+**Role.** Everything that turns an intent into tokens.
+
+**Internal organisation.** `internal/ai/` at the root holds the public contract (`Engine`, `Strategy`, `Request`, `Event`, `ResolveModel`, `Message`, `ToolCall`, `ToolSpec`). Implementations live in private sub-packages: `ai/provider/` holds the concrete drivers (API / CLI / Codex / Registry).
+
+**Minimum contract.**
+
+```go
+type Engine interface {
+    Run(ctx context.Context, req Request) (<-chan Event, error)
+}
+
+type Request struct {
+    Model       ModelID        // resolved by ResolveModel, never hard-coded
+    Messages    []Message      // supplied by Memory, not re-read by AI
+    Tools       []Capability   // supplied by Runtime, not picked by AI
+    MaxTokens   int
+    Stream      bool
+}
+
+// Strategy describes how to chain multiple Engine.Run calls for a single
+// turn (retry, chain-of-thought, parallel, single-shot, ...). Runtime picks
+// the Strategy; ai/ owns the contract, not the orchestration machinery
+// (sessions, task store, spawning — those live in runtime/).
+type Strategy interface {
+    Run(ctx context.Context, engine Engine, req Request) (<-chan Event, error)
+}
+```
+
+**Hard rules.**
+- **One `ResolveModel`, everywhere.** A CI test (`TestHardcodedModelFallback`) fails when a hard-coded fallback sneaks into any other package.
+- AI **does not read** Memory directly. Runtime prepares the Request.
+- AI **does not execute** Capabilities. It emits `ToolCall` events; Runtime runs them.
+- `ai/` owns the `Strategy` contract. Concrete orchestrators (agents, classifier router) live in `runtime/`.
+
+### 2.4 `sandbox/`
+
+**Role.** Enforce per-Capability access policies.
+
+**Sub-packages.**
+- `sandbox/exec/` — chroot + setpriv + per-app namespaces for executing Capabilities.
+- `sandbox/integrity/` — hash-based tool/script integrity (TOCTOU-safe via exec-time hash).
+- `sandbox/network/` — firewall proxy + outbound allow/deny rules.
+- `sandbox/secrets/` — vault + per-app proxy socket. **Note:** this is distinct from `internal/envsecrets/` (the env-var / Docker-secret reader at boot).
+
+**Minimum contract.**
+
+```go
+type Policy struct {
+    FileAccess  FileRules    // read/write paths authorised
+    Network     NetworkRules // domains authorised
+    Secrets     SecretRules  // vault keys accessible
+    Tier        Tier         // aggregated capabilities
+}
+
+type Sandbox interface {
+    // Returns a ctx that cap.Execute() must run inside.
+    Apply(ctx context.Context, cap Capability, policy Policy) (context.Context, error)
+}
+```
+
+**Hard rules.**
+- **One Policy applies to one Capability.** No implicit accumulation.
+- The Policy is **derived from the Capability's Manifest** plus the user tier. Never ad hoc.
+- Firewall (network), Vault (secrets), Filesystem (exec) and Integrity are **four facets** of the same Sandbox.
+- Integrity scanning runs **inside** the Sandbox, not alongside it.
+- **This is the central promise of ALF.** Enforcement is staged — integrity is wired today; facet wire-in (network/secrets/filesystem through `PolicyFrom(ctx)`) is the v0.8.0 follow-up.
+
+### 2.5 `runtime/`
+
+**Role.** Orchestrate the four other blocks. The **only** package that knows them all.
+
+**Sub-packages.**
+- `runtime/agents/` — multi-agent orchestrator (absorbed from the old `agents/` package).
+- `runtime/classifier/` — tier classifier (absorbed from the old `router/` classifier).
+
+**Minimum contract.**
+
+```go
+type Runtime interface {
+    // Process one user chat turn.
+    Chat(ctx context.Context, convID memory.ConvID, userInput string) (<-chan Event, error)
+
+    // Execute a one-shot Capability (UI button, scheduler, ...).
+    Invoke(ctx context.Context, capID CapabilityID, args Args) (Output, error)
+
+    // Streaming variants (Converse / ConverseStream) for chat pipelines.
+}
+```
+
+**What Runtime does.**
+1. Resolves the Capability from the registry.
+2. Loads history from Memory (scoped by convID).
+3. Derives the Policy from the Manifest + tier.
+4. Calls `Sandbox.Apply` to prepare the ctx.
+5. Runs `AI.Run` with the prepared Request.
+6. Loops on `ToolCall` events: executes each Capability via Sandbox, re-injects results.
+7. Persists the turn into Memory.
+
+**Hard rules.**
+- Runtime is the **only** package that imports `capability + memory + ai + sandbox` together.
+- None of the four blocks imports Runtime.
+- Consumers (controlcenter, telegram, scheduler) import **only** Runtime.
+
+---
+
+## 3. Periphery
+
+These packages do not participate in the core sentence. They are consumers or plumbing.
+
+### User-facing consumers
+- `cli/` — host CLI
+- `controlcenter/` — web UI
+- `telegram/` — Telegram bot
+- `voice/` — voice transcription bridge
+- `scheduler/` — cron-based invoker (consumer of `Runtime.Invoke`)
+
+### Ops / plateform (`platform/`)
+Grouped under `internal/platform/` to make the block-vs-periphery separation visible:
+
+- `platform/eventlog/` — append-only event log
+- `platform/gittrack/` — git repo watcher (extraction signal)
+- `platform/media/` — image/video/PDF processing
+- `platform/mood/` — daily personality layer
+- `platform/session/` — CLI session bookkeeping
+- `platform/signal/` — Unix-socket server for in-sandbox Telegram/reaction calls
+- `platform/supervisor/` — background service manager (restart policies)
+- `platform/tlsgen/` — self-signed cert generator for local HTTPS
+- `platform/trace/` — chain/task tracing
+- `platform/updater/` — image-update notifier
+- `platform/vulncheck/` — `govulncheck` wrapper (CI guard)
+
+### Ancillary (still at `internal/` root)
+- `envsecrets/` — Docker / Kubernetes env-var secret reader at boot. Distinct from `sandbox/secrets/`.
+- `marketplace/` — app installer + permission gate + lifecycle manager. Registers apps as Capabilities via `capability_adapter.go`.
+- `skills/` — skills FS store + prompt catalog + trigger matching. Registers skills as Capabilities via `capability_adapter.go`.
+- `tooling/` — tool discovery (scan `tools.d/*.json`), native-tool host, integrity integration. Registers tools as Capabilities via `capability_adapter.go`.
+- `comms/` — legacy chat pipeline. Its absorption into `runtime/` is tracked in issue #377 (v0.8.0).
+- `archtest/` — CI-only package that enforces dependency rules.
+
+---
+
+## 4. Dependency rules
+
+```
+consumers (controlcenter, telegram, scheduler, cli, ...)
+    │
+    ▼
+  runtime
+    │
+    ├──► capability
+    ├──► memory
+    ├──► ai
+    └──► sandbox
+```
+
+**Hard forbidden imports:**
+- `capability` **must not** import memory, ai, sandbox, runtime.
+- `memory` **must not** import capability, ai, sandbox, runtime.
+- `ai` **must not** import capability, memory, sandbox, runtime.
+- `sandbox` **must not** import capability (it takes a `Manifest` as parameter), memory, ai, runtime.
+- **Only runtime** may import the four.
+- No consumer imports one of the four blocks directly (apart from public types re-exposed via runtime).
+
+A CI test enforces these rules (`internal/archtest/deps_test.go` — `TestFoundationDependencyRules`, `TestConsumerDependencyRules`). It runs in enforcing mode.
+
+A second CI test (`TestHardcodedModelFallback`) fails when any file outside `ai/resolve.go` introduces a model fallback string.
+
+---
+
+## 5. Decision tree: where does my new file belong?
+
+Use this when adding a new file or package:
+
+1. **Is it executable by the AI (a tool, skill, or app)?**
+   → `capability/` contract + register through the adapter in `tooling/`, `skills/`, or `marketplace/`.
+
+2. **Does it persist or recall data (conversations, embeddings, preferences)?**
+   → `memory/` (or a sub-package under `memory/`).
+
+3. **Does it turn an intent into tokens (provider driver, strategy, model resolution)?**
+   → `ai/` (contract) or `ai/provider/` (concrete driver).
+
+4. **Does it enforce a policy (file access, network, secrets, integrity)?**
+   → `sandbox/` (or a facet sub-package).
+
+5. **Does it orchestrate the four (pipelines, agents, classifier)?**
+   → `runtime/`.
+
+6. **Is it a user-facing surface (CLI, web UI, Telegram, voice, scheduler)?**
+   → root-level consumer package (`cli/`, `controlcenter/`, `telegram/`, `voice/`, `scheduler/`).
+
+7. **Is it ops plumbing (cron, tracing, supervision, updater, cert gen, event log, …)?**
+   → `platform/<name>/`.
+
+8. **None of the above?** → 🚨 Red flag. Open a discussion issue before you code.
+
+---
+
+## 6. Acceptance criteria
+
+The architecture is honoured when:
+
+1. The 5 packages (`capability`, `memory`, `ai`, `sandbox`, `runtime`) exist and respect the dependency rules (CI-verified).
+2. Old fused packages (`chatdb`, `conversation`, `memstore`, `firewall`, `vault`, `router`, `provider`, `agents` standalone) no longer exist.
+3. No user-facing behaviour change from the refactor (regression tests green).
+4. Average PR diff on a bug fix is under 3 files (measured on the next fix cycle).
+5. `ResolveModel` is unique and protected by a CI test.
+6. `CurrentConvID` is a preference read from Memory, not a memory-state field.
+7. A new contributor can point to one of the 5 blocks for 80 % of "where do I touch for X?" questions.
+
+---
+
+## 7. What this architecture is NOT
+
+- ❌ A rewrite. It is a reorganisation — the business code stays, it changes address.
+- ❌ A place to add new features without going through the decision tree.
+- ❌ A static document — when reality diverges from this text, we change whichever is wrong (usually the text).
+
+## 8. Why it exists
+
+The 0.7.8 cycle produced ~30 fixes, five of them alone on `chat / multi-tab / conv scoping`. The common root: conversational state scattered across four packages (`chatdb`, `conversation`, `memstore`, `memory`) and `convID` scoping absent from function signatures.
+
+Without this rework each cycle repeats the same pattern. With it, the class of bugs disappears by construction.


### PR DESCRIPTION
## Summary

Closes #342.

Two commits on this branch:

1. **Structural refresh** — publishes the 5-block architecture in contributor-facing form.
   - New `docs/ARCHITECTURE.md` (canonical, versionless).
   - README "How it works" replaces the old `chat engine → router → provider` narrative (which referenced deleted packages) with the 5-block diagram + pointer to `docs/ARCHITECTURE.md`.
   - CONTRIBUTING rewritten around the 5 blocks: decision tree "where does my new file belong?", dependency rules summary + pointer to the archtest CI tests, golden rule (red flag if a new package fits nowhere). Fixed every stale path (chatdb, conversation, memstore, firewall, vault, router, provider, agents, supervisor→platform/, trace→platform/, signal→platform/, tlsgen→platform/).

2. **Backend-agnostic positioning** — ALF was presented as a "Claude bot" in the intro; reality is three backend families (CLI, API, Local). Rewritten:
   - README "Why ALF" bullets now explain the 3 backend families (CLI = Claude Code or Codex; API = OpenRouter/OpenAI/any OpenAI-compatible; Local = Ollama).
   - Tier table adds a \`backend\` row; model examples pulled from multiple providers.
   - \`alf login\` explicitly scoped to the \`cli\` backend only.
   - Media / Requirements / Multi-backend sections cleaned up.
   - Claude is still named (it's the backend of choice for many) — just no longer as THE backend.

## Test plan

- [x] \`grep Claude\` sweep — remaining mentions are contextual (naming Claude as one backend option), no more Claude-centric framing
- [x] \`grep internal/(chatdb|conversation|memstore|firewall|vault|router|provider|agents)\` — clean
- [x] No code change, no behavior change
- [x] Follows #375, #376, #379 (0.7.9 milestone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)